### PR TITLE
Fix VS Code extension launch stability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage/
 playwright-report/
 test-results/
 artifacts/
+.vscode/chrome-debug-profile/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,13 +2,14 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Debug Playwright Chromium Extension",
-      "type": "pwa-chrome",
+      "name": "Run Playwright Chromium Extension",
+      "type": "chrome",
       "request": "launch",
-      "preLaunchTask": "Build Dev and Install Playwright Chromium",
+      "preLaunchTask": "Build Dev and Ensure Playwright Chromium",
       "runtimeExecutable": "${env:LOCALAPPDATA}\\ms-playwright\\chromium-1217\\chrome-win64\\chrome.exe",
-      "url": "chrome://newtab/",
-      "userDataDir": true,
+      "url": "about:blank",
+      "urlFilter": "about:blank",
+      "userDataDir": "${workspaceFolder}\\.vscode\\chrome-debug-profile",
       "runtimeArgs": [
         "--load-extension=${workspaceFolder}/dist",
         "--disable-extensions-except=${workspaceFolder}/dist",
@@ -17,8 +18,9 @@
         "--no-first-run",
         "--no-default-browser-check"
       ],
-      "webRoot": "${workspaceFolder}/src",
-      "sourceMaps": true
+      "webRoot": "${workspaceFolder}/dist",
+      "sourceMaps": false,
+      "pauseForSourceMap": false
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,9 +2,9 @@
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Install Dependencies",
+      "label": "Ensure Dependencies",
       "type": "shell",
-      "command": "npm ci",
+      "command": "if (Test-Path .\\node_modules\\.bin\\vite.cmd) { Write-Host 'Dependencies already installed.' } else { npm ci }",
       "problemMatcher": []
     },
     {
@@ -30,9 +30,9 @@
       "problemMatcher": []
     },
     {
-      "label": "Build Dev and Install Playwright Chromium",
+      "label": "Build Dev and Ensure Playwright Chromium",
       "dependsOrder": "sequence",
-      "dependsOn": ["Install Dependencies", "Build Dev", "Install Playwright Chromium"],
+      "dependsOn": ["Ensure Dependencies", "Build Dev", "Install Playwright Chromium"],
       "problemMatcher": []
     },
     {


### PR DESCRIPTION
## Context

Issue #67 reports that the VS Code F5 workflow can still leave the extension experience stuck, likely because the browser debugger is pausing on a breakpoint or otherwise attaching to the wrong extension target. The built extension itself already loads in Chromium; the problematic part is the development launch/debug wrapper around it.

This PR changes the VS Code workflow to treat F5 as "run the unpacked extension in Playwright Chromium" instead of "debug every Chrome target that appears." That keeps the normal extension UI available for manual validation without letting stale breakpoints, exception pausing, or source-map attachment behavior freeze the popup/options pages.

Closes #67

## What changed

- Renamed the VS Code launch configuration from `Debug Playwright Chromium Extension` to `Run Playwright Chromium Extension`.
- Switched the debug type from legacy `pwa-chrome` to the current `chrome` type.
- Changed the startup URL from `chrome://newtab/` to `about:blank`.
- Added `urlFilter: "about:blank"` so VS Code attaches only to the inert startup tab and does not automatically attach to extension UI targets.
- Changed `userDataDir` from an anonymous generated profile to `.vscode/chrome-debug-profile`, giving developers a deterministic profile folder they can delete if Chrome state becomes suspect.
- Pointed `webRoot` at `dist`, disabled source maps, and disabled `pauseForSourceMap` for this run-oriented workflow.
- Replaced the repeated `Install Dependencies` task with `Ensure Dependencies`, which skips `npm ci` when the Vite binary is already present.
- Updated the combined prelaunch task name to match the new dependency behavior.
- Ignored `.vscode/chrome-debug-profile/` so normal F5 sessions do not dirty the worktree.

## Decision details

The attachment scope is the central fix. The previous launch configuration started Chromium with the extension loaded, but left VS Code's browser debugger broadly attached with source maps enabled. For an extension workflow, popup/options/blocked/background targets are created dynamically, and a paused debugger state in any of those targets can look like the product itself is hung. Filtering attachment to `about:blank` leaves Chromium under VS Code's lifecycle management while keeping the extension pages out of js-debug's breakpoint machinery.

`about:blank` is intentionally boring. It avoids `chrome://newtab/` special-page behavior and gives `urlFilter` a precise, stable target. The extension still loads through the existing `--load-extension` and `--disable-extensions-except` arguments, so this does not change the extension artifact being exercised.

The workflow keeps `--enable-unsafe-extension-debugging` and `--disable-features=DisableLoadExtensionCommandLineSwitch` because those flags are still needed for Chromium extension loading/debugging behavior in the Playwright Chromium build. The change is about narrowing VS Code attachment, not weakening Chromium's ability to load the unpacked extension.

Source maps are disabled in this configuration because the issue is about the run/manual-debug workflow getting stuck, not about source-level debugging. If a developer needs real breakpoint debugging later, that should be a separate, explicitly named attach/debug configuration so there is no ambiguity between "run the extension for manual testing" and "attach to extension code and allow breakpoints."

The deterministic profile path is deliberate. `userDataDir: true` creates a profile managed by the debugger extension, which is convenient but opaque when the profile gets into a bad state. A workspace-local `.vscode/chrome-debug-profile` gives a clear workaround: delete that folder and rerun F5. Ignoring it prevents normal runs from creating untracked noise.

The dependency task change is included because the same F5 workflow was repeatedly running `npm ci`. That is useful for first-run setup but expensive and fragile during routine debugging on Windows, especially when npm tries to replace files that may be locked by tools or native modules. Checking for `node_modules/.bin/vite.cmd` preserves automatic setup for a fresh checkout while avoiding unnecessary reinstall work when dependencies are already present.

## Validation

- `npx prettier --check .vscode\launch.json .vscode\tasks.json --ignore-unknown`
- `npm run build:dev`
- `npm run lint`
- `npm run typecheck`
- `npm run test:e2e`

The first full e2e run had two transient failures, both passed when rerun directly, and the full suite then passed 10/10.

## Manual verification notes

After this change, use the `Run Playwright Chromium Extension` launch configuration. If Chromium still shows stale behavior after repeated launches, close the launched browser and delete `.vscode/chrome-debug-profile`; it will be recreated on the next F5 run.
