### PR TITLE
Fix popup filter URL fallback

### DIFF
--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -708,7 +708,10 @@ async function renderFilters(): Promise<void> {
     const group = groupsById.get(filter.groupId);
     const groupName = group?.name ?? 'Unknown Group';
     const description = filter.description?.trim();
-    const displayName = description ?? filter.pattern;
+    let displayName = filter.pattern;
+    if (description) {
+      displayName = description;
+    }
     const toggleLabel = description
       ? `Toggle filter ${description}`
       : `Toggle filter for ${filter.pattern}`;

--- a/test/e2e/popup.spec.ts
+++ b/test/e2e/popup.spec.ts
@@ -37,6 +37,31 @@ test('adds and deletes a temporary filter from the popup', async ({ extensionPag
   await expect(page.getByText('No filters configured.')).toBeVisible();
 });
 
+test('shows the URL pattern when a filter name is blank', async ({ extensionPage, page }) => {
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await seedStorage(
+    page,
+    createStorageData({
+      filters: [
+        {
+          id: 'plain-url-filter',
+          pattern: 'github.com/notifications',
+          groupId: defaultGroup.id,
+          enabled: true,
+          matchMode: 'contains',
+          description: '',
+        },
+      ],
+    })
+  );
+
+  await page.goto(extensionPage(PAGES.POPUP));
+
+  await expect(
+    page.locator('.filter-item').filter({ hasText: 'github.com/notifications' })
+  ).toBeVisible();
+});
+
 test('supports copy, toggle, and edit actions for popup filters', async ({
   context,
   extensionPage,


### PR DESCRIPTION
## What changed

- Updated the popup filter label rendering to default to the filter pattern and only replace it with a trimmed name when that name has content.
- Added popup e2e coverage for a saved filter whose name is an empty string, matching the regression case where URL-only filters disappeared from the list.

## Why

Filters saved without a title can still have `description: ''`. The popup used nullish fallback for the label, so an empty string was treated as a valid display value instead of falling back to the URL pattern. That made plain URL filters render with a blank title even though the pattern should remain visible.

## Impact

Users once again see either the saved title or the URL/pattern in the popup filter list, including filters saved without a name.

## Validation

- `npx.cmd prettier --check src/popup/index.ts test/e2e/popup.spec.ts`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run typecheck:test`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `npx.cmd playwright test test/e2e/popup.spec.ts`

Note: `npm.cmd run check:fast` still stops at repository-wide `format:check` because many unrelated files already fail Prettier formatting; the two touched files pass targeted Prettier check.
