### PR TITLE
Add global settings placeholder

### DIFF
--- a/src/options/index.html
+++ b/src/options/index.html
@@ -123,6 +123,18 @@
           New Group
         </button>
       </div>
+
+      <details class="group-item options-placeholder-group" open>
+        <summary class="group-header">
+          <div class="group-info">
+            <div class="group-title">Global Settings</div>
+            <div class="filter-meta">Extension-wide preferences and defaults</div>
+          </div>
+        </summary>
+        <div class="group-content">
+          <p class="empty-state">Global settings controls will appear here.</p>
+        </div>
+      </details>
     </div>
 
     <template id="options-group-template">

--- a/src/options/styles/options.css
+++ b/src/options/styles/options.css
@@ -513,6 +513,10 @@ label {
   box-shadow: var(--shadow-sm);
 }
 
+.options-placeholder-group {
+  margin-top: 1.25rem;
+}
+
 .group-header {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Adds an expanded Global Settings placeholder section below the existing options-page filter groups.

<img width="1606" height="823" alt="image" src="https://github.com/user-attachments/assets/c6a93a38-18b4-4d8d-85eb-990b2fa1d484" />

This reserves a clear extension-wide settings area so follow-up PRs can add actual global controls without restructuring the options page later. The section is static for now and does not change storage, filtering behavior, or existing group management.
