### PR TITLE
Refine AGENTS.md as a harness routing layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,13 +6,7 @@ Keep this file short and repo-specific.
 
 Use this file as a routing layer for agents, not as a second copy of repository config.
 Prefer harness-style guidance: point to the live source of truth, keep instructions compact,
-and avoid examples that can drift from the real files. OpenAI's harness engineering writeup
-recommends treating repository knowledge as the system of record and `AGENTS.md` as a table of
-contents, not an encyclopedia: https://openai.com/index/harness-engineering/
-
-The goal is agent legibility. Future agents should be able to inspect the repository, understand
-the product boundaries, run the checks, and improve the durable harness when the current one is
-missing a rule, test, or source-of-truth document.
+and avoid examples that can drift from the real files.
 
 ## Source-of-truth files
 
@@ -44,8 +38,7 @@ Read the real files before making assumptions:
 4. Inspect nearby implementation and matching tests before changing behavior.
 5. Validate with the repo's existing npm scripts from `package.json`.
 6. If a command fails because local prerequisites are missing, install the documented prerequisite and rerun.
-7. If a repeated issue would be better caught by automation, add or update the relevant test, type,
-   lint rule, script, or documentation source of truth instead of adding more prose here.
+7. Prefer executable checks or source documentation over adding more prose here.
 
 ## Extension-specific reminders
 
@@ -56,18 +49,7 @@ Read the real files before making assumptions:
 - Keep popup, options, blocked-page, background, and shared modules within their existing ownership boundaries
   unless the change intentionally moves behavior into a shared layer.
 
-## Harness maintenance
-
-Use review feedback and recurring defects to improve the harness in durable places:
-
-1. Prefer executable checks: tests, TypeScript types, lint rules, scripts, and CI.
-2. Prefer source documentation for product, architecture, and workflow decisions.
-3. Use this file only for stable repo-wide routing and invariants.
-4. When documentation and code disagree, trust the code and tests first, then update the stale document.
-
 ## When updating this file
 
 Only add durable, repo-wide guidance here.
 If a detail already lives in a committed file, link to that file instead of copying its contents.
-Keep this file small enough that agents can read it at the start of every task without crowding out
-the task, code, tests, and source-of-truth files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,18 @@
-# AGENTS.md — Teichos
+# AGENTS.md - Teichos
 
 Keep this file short and repo-specific.
 
 ## Purpose
 
 Use this file as a routing layer for agents, not as a second copy of repository config.
-Prefer Harness-style guidance: point to the live source of truth, keep instructions compact,
-and avoid examples that can drift from the real files.
+Prefer harness-style guidance: point to the live source of truth, keep instructions compact,
+and avoid examples that can drift from the real files. OpenAI's harness engineering writeup
+recommends treating repository knowledge as the system of record and `AGENTS.md` as a table of
+contents, not an encyclopedia: https://openai.com/index/harness-engineering/
+
+The goal is agent legibility. Future agents should be able to inspect the repository, understand
+the product boundaries, run the checks, and improve the durable harness when the current one is
+missing a rule, test, or source-of-truth document.
 
 ## Source-of-truth files
 
@@ -35,16 +41,33 @@ Read the real files before making assumptions:
 1. Read the relevant source-of-truth files first.
 2. Prefer updating the real config or documentation file over restating it here.
 3. Keep changes minimal and consistent with the existing structure.
-4. Validate with the repo's existing npm scripts from `package.json`.
-5. If a command fails because local prerequisites are missing, install the documented prerequisite and rerun.
+4. Inspect nearby implementation and matching tests before changing behavior.
+5. Validate with the repo's existing npm scripts from `package.json`.
+6. If a command fails because local prerequisites are missing, install the documented prerequisite and rerun.
+7. If a repeated issue would be better caught by automation, add or update the relevant test, type,
+   lint rule, script, or documentation source of truth instead of adding more prose here.
 
 ## Extension-specific reminders
 
 - Manifest V3 service worker code must stay event-driven and should not rely on persistent in-memory state.
 - Prefer the shared logic in `src/shared` over duplicating types or storage behavior across entry points.
 - Treat tests as executable documentation: update or read the matching unit/e2e tests before changing behavior.
+- Validate external browser, storage, and message shapes at the boundary before depending on them.
+- Keep popup, options, blocked-page, background, and shared modules within their existing ownership boundaries
+  unless the change intentionally moves behavior into a shared layer.
+
+## Harness maintenance
+
+Use review feedback and recurring defects to improve the harness in durable places:
+
+1. Prefer executable checks: tests, TypeScript types, lint rules, scripts, and CI.
+2. Prefer source documentation for product, architecture, and workflow decisions.
+3. Use this file only for stable repo-wide routing and invariants.
+4. When documentation and code disagree, trust the code and tests first, then update the stale document.
 
 ## When updating this file
 
 Only add durable, repo-wide guidance here.
 If a detail already lives in a committed file, link to that file instead of copying its contents.
+Keep this file small enough that agents can read it at the start of every task without crowding out
+the task, code, tests, and source-of-truth files.


### PR DESCRIPTION
## Proposal

This PR updates `AGENTS.md` so it works as a compact harness entry point for Teichos while remaining a single file. The intent is not to add a second project manual. The intent is to make the existing file better at routing future agents to the real sources of truth, executable checks, and repo-specific boundaries.

The rationale belongs here in the PR, not in `AGENTS.md`. Keeping meta-reasoning out of the agent instruction file matters because agents should spend their context budget on the current task, source files, tests, and validation output.

The change follows three principles from OpenAI's harness engineering writeup: https://openai.com/index/harness-engineering/

1. Keep repository knowledge in the repository. The article argues that knowledge outside the repo is effectively unavailable to an agent during a run, so durable guidance should live in versioned files that agents can inspect.
2. Treat `AGENTS.md` as a table of contents rather than an encyclopedia. The article describes moving away from a large single instruction file because excessive guidance consumes context, goes stale, and becomes hard to verify.
3. Prefer enforceable feedback loops. The article emphasizes that architecture and taste scale better when encoded as tests, linters, scripts, and structural constraints instead of prose-only review preferences.

## What changed

- Keeps `AGENTS.md` short and operational.
- Preserves the current source-of-truth routing model.
- Adds a workflow step to inspect nearby implementation and matching tests before behavior changes.
- Compresses harness improvement guidance into one action-oriented line: prefer executable checks or source documentation over adding more prose.
- Adds extension-specific reminders for validating browser/storage/message boundaries and preserving ownership between background, popup, options, blocked-page, and shared modules.

## Why this shape

This keeps the file intentionally small. The OpenAI article identifies large monolithic instruction files as costly because they crowd out task context, make every rule appear equally important, rot quickly, and are hard to verify. Teichos does not need a full documentation hierarchy yet, so this PR keeps the current single-file constraint while still applying the same operating model: short map, durable references, executable checks first.

The new language also fits the existing repo. Teichos already has clear source-of-truth files (`README.md`, `manifest.json`, `package.json`, Vite/TypeScript/ESLint config, CI, and unit/e2e tests). The change tells agents to use those files directly instead of restating their contents in `AGENTS.md`.

## Follow-up work

The next useful step, once the project needs more structure, is to split durable detail out of `AGENTS.md` into focused repo-local docs such as `docs/ARCHITECTURE.md`, `docs/QUALITY.md`, or `docs/TESTING.md`. That follows the same OpenAI article's recommendation to use a structured repository knowledge base with a short `AGENTS.md` entry point.

A second follow-up is adding mechanical checks for any rule that starts recurring in review. The article's strongest practical point is that documentation alone does not maintain coherence; constraints should be enforced through tools where possible. For Teichos, likely candidates would be architectural boundary checks between `src/background`, `src/shared`, and UI entry points, or targeted tests around extension message/storage contracts.

These are follow-ups, not prerequisites for this PR. This PR keeps the current one-file model and makes it easier to evolve later without adding premature structure.

## Validation

- `npx prettier --check AGENTS.md`