### PR TITLE
Improve lifecycle E2E reliability for blocked/allowed transitions

### DIFF
--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -55,11 +55,14 @@ export async function expectBlocked(
   expectedBlockedUrl = getBlockedPagePathFor(targetUrl)
 ): Promise<void> {
   await expect
-    .poll(async () => {
-      await page.goto(targetUrl).catch(() => undefined);
-      const currentUrl = page.url();
-      return new URL(currentUrl).pathname + new URL(currentUrl).search;
-    }, { timeout: 15_000 })
+    .poll(
+      async () => {
+        await page.goto(targetUrl).catch(() => undefined);
+        const currentUrl = page.url();
+        return new URL(currentUrl).pathname + new URL(currentUrl).search;
+      },
+      { timeout: 15_000 }
+    )
     .toBe(expectedBlockedUrl);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
@@ -67,10 +70,13 @@ export async function expectBlocked(
 
 export async function expectAllowed(page: Page, targetUrl: string): Promise<void> {
   await expect
-    .poll(async () => {
-      await page.goto(targetUrl).catch(() => undefined);
-      return page.url();
-    }, { timeout: 15_000 })
+    .poll(
+      async () => {
+        await page.goto(targetUrl).catch(() => undefined);
+        return page.url();
+      },
+      { timeout: 15_000 }
+    )
     .not.toContain(`/${PAGES.BLOCKED}`);
 }
 

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -54,17 +54,24 @@ export async function expectBlocked(
   targetUrl: string,
   expectedBlockedUrl = getBlockedPagePathFor(targetUrl)
 ): Promise<void> {
-  await page.goto(targetUrl).catch(() => undefined);
   await expect
-    .poll(() => new URL(page.url()).pathname + new URL(page.url()).search)
+    .poll(async () => {
+      await page.goto(targetUrl).catch(() => undefined);
+      const currentUrl = page.url();
+      return new URL(currentUrl).pathname + new URL(currentUrl).search;
+    }, { timeout: 15_000 })
     .toBe(expectedBlockedUrl);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
 }
 
 export async function expectAllowed(page: Page, targetUrl: string): Promise<void> {
-  await page.goto(targetUrl).catch(() => undefined);
-  await expect.poll(() => page.url()).not.toContain(`/${PAGES.BLOCKED}`);
+  await expect
+    .poll(async () => {
+      await page.goto(targetUrl).catch(() => undefined);
+      return page.url();
+    }, { timeout: 15_000 })
+    .not.toContain(`/${PAGES.BLOCKED}`);
 }
 
 export async function openOptions(

--- a/test/e2e/lifecycle.spec.ts
+++ b/test/e2e/lifecycle.spec.ts
@@ -111,7 +111,6 @@ test('an already-blocked tab becomes allowed and clears stale state after popup 
       ],
     })
   );
-
   const browsingPage = await context.newPage();
   await expectBlocked(browsingPage, targetUrl);
   await expect
@@ -158,6 +157,13 @@ test('popup toggle changes navigation behavior and direct storage updates refres
       ],
     })
   );
+  await expect
+    .poll(async () =>
+      (await readStorage(page))?.filters.some(
+        (filter) => filter.id === 'primed-filter' && filter.enabled
+      )
+    )
+    .toBe(true);
 
   const browsingPage = await context.newPage();
   const popupPage = await openPopup(extensionPage, page);


### PR DESCRIPTION
### Motivation
- Reduce intermittent flakiness in lifecycle e2e tests caused by races between storage updates, background rule propagation, and page navigation.
- Make navigation assertions more resilient to transient delays in CI-like environments.

### Description
- Update `expectBlocked` and `expectAllowed` in `test/e2e/helpers.ts` to perform the navigation inside an `expect.poll` so the navigation+assertion are retried until successful.
- Increase the navigation assertion polling timeout to `15_000` ms to tolerate extension update latency during tests.
- Add an explicit storage-read synchronization checkpoint in the primed-rules lifecycle scenario in `test/e2e/lifecycle.spec.ts` so the test verifies the rule is present/primed before continuing.
- Changes touch `test/e2e/helpers.ts` and `test/e2e/lifecycle.spec.ts` to gate known races and reduce timing sensitivity.

### Testing
- Ran `npm run build` and it completed successfully.
- Ran `npm run playwright:install` to ensure Playwright browsers were available and it completed successfully.
- Ran the targeted e2e tests with `npx playwright test test/e2e/lifecycle.spec.ts -g "options filter lifecycle blocks, restores, and blocks again after re-enable|direct storage updates allow navigation after background rules are already primed|expired temporary filters do not prevent real navigation from being blocked"` and the three focused tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a125785d258832885a3d4ff3f1a6a29)