### PR TITLE
Reconcile blocked tab state from current target

### DIFF
--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -12,6 +12,11 @@ import { STORAGE_KEY, type BlockedTabState } from '../shared/types';
 import { isInternalUrl, type FilterDecision } from '../shared/utils';
 import { getRulesProvider, type CurrentRules, type RulesProvider } from './rulesProvider';
 
+interface ResolvedBlockedTarget {
+  readonly targetUrl: string;
+  readonly hasSessionState: boolean;
+}
+
 class TabController {
   private didRegister = false;
   private reconcileQueue: Promise<void> = Promise.resolve();
@@ -64,21 +69,36 @@ class TabController {
   }
 
   async restoreIfAllowed(tabId: number, blockedPageUrl?: string): Promise<boolean> {
-    const state = await this.resolveBlockedTabState(tabId, blockedPageUrl);
-    if (!state) {
+    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
+    if (!resolvedTarget) {
       return false;
     }
 
     const rules = await this.getRules();
-    const decision = rules.engine.evaluate(state.targetUrl);
-    if (decision.action === 'block') {
-      await this.setBlockedState(tabId, state.targetUrl, decision, rules.data.rulesVersion);
+    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
+    if (state) {
       return false;
     }
 
-    await updateTabUrl(tabId, state.targetUrl);
-    await this.allowTab(tabId, state.targetUrl);
+    await updateTabUrl(tabId, resolvedTarget.targetUrl);
+    await this.allowTab(tabId, resolvedTarget.targetUrl);
     return true;
+  }
+
+  async getFreshBlockedTabState(
+    tabId: number,
+    blockedPageUrl?: string
+  ): Promise<BlockedTabState | undefined> {
+    if (!Number.isInteger(tabId)) {
+      return undefined;
+    }
+
+    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
+    if (!resolvedTarget) {
+      return undefined;
+    }
+
+    return this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
   }
 
   async reconcileAllOpenTabs(): Promise<void> {
@@ -136,21 +156,20 @@ class TabController {
   }
 
   private async reconcileBlockedTab(tabId: number, blockedPageUrl?: string): Promise<void> {
-    const state = await this.resolveBlockedTabState(tabId, blockedPageUrl);
-    if (!state) {
+    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
+    if (!resolvedTarget) {
       return;
     }
 
     const rules = await this.getRules();
-    const decision = rules.engine.evaluate(state.targetUrl);
-
-    if (decision.action === 'allow') {
-      await updateTabUrl(tabId, state.targetUrl);
-      await this.allowTab(tabId, state.targetUrl);
+    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
+    if (!state) {
+      if (resolvedTarget.hasSessionState) {
+        await updateTabUrl(tabId, resolvedTarget.targetUrl);
+        await this.allowTab(tabId, resolvedTarget.targetUrl);
+      }
       return;
     }
-
-    await this.setBlockedState(tabId, state.targetUrl, decision, rules.data.rulesVersion);
   }
 
   private async blockTab(
@@ -173,7 +192,7 @@ class TabController {
     targetUrl: string,
     decision: Extract<FilterDecision, { action: 'block' }>,
     rulesVersion: number
-  ): Promise<void> {
+  ): Promise<BlockedTabState> {
     const state: BlockedTabState = {
       tabId,
       targetUrl,
@@ -186,42 +205,40 @@ class TabController {
     };
 
     await setBlockedTabState(state);
+    return state;
   }
 
-  private async resolveBlockedTabState(
+  private async resolveBlockedTarget(
     tabId: number,
     blockedPageUrl?: string
-  ): Promise<BlockedTabState | undefined> {
+  ): Promise<ResolvedBlockedTarget | undefined> {
     const existingState = await getBlockedTabState(tabId);
-    if (existingState) {
-      return existingState;
-    }
-
     const fallbackTargetUrl = parseBlockedTargetUrl(blockedPageUrl);
-    if (!fallbackTargetUrl) {
-      return undefined;
+    if (fallbackTargetUrl) {
+      return {
+        targetUrl: fallbackTargetUrl,
+        hasSessionState: Boolean(existingState),
+      };
     }
 
-    // Migration path for blocked tabs that were created before blocked-tab
-    // session state started being recorded.
-    const rules = await this.getRules();
-    const decision = rules.engine.evaluate(fallbackTargetUrl);
+    return existingState
+      ? { targetUrl: existingState.targetUrl, hasSessionState: true }
+      : undefined;
+  }
+
+  private async refreshBlockedTabState(
+    tabId: number,
+    targetUrl: string,
+    currentRules?: CurrentRules
+  ): Promise<BlockedTabState | undefined> {
+    const rules = currentRules ?? (await this.getRules());
+    const decision = rules.engine.evaluate(targetUrl);
     if (decision.action !== 'block') {
+      await clearBlockedTabState(tabId);
       return undefined;
     }
 
-    const state: BlockedTabState = {
-      tabId,
-      targetUrl: fallbackTargetUrl,
-      blockedAt: Date.now(),
-      rulesVersion: rules.data.rulesVersion,
-      blockedBy: {
-        filterId: decision.filterId,
-        groupId: decision.groupId,
-      },
-    };
-    await setBlockedTabState(state);
-    return state;
+    return this.setBlockedState(tabId, targetUrl, decision, rules.data.rulesVersion);
   }
 
   private queueReconcile(): void {

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -152,6 +152,97 @@ describe('TabController', () => {
     await expect(getLastAllowedUrl(5)).resolves.toBe('https://blocked.com/focus');
   });
 
+  it('reconciles the target from the current blocked page before stale session state', async () => {
+    const chromeMock = getChromeMock();
+    chromeMock.storage.sync._data.set(
+      STORAGE_KEY,
+      createStorageData({
+        filters: [
+          {
+            id: 'stale-filter',
+            pattern: 'stale-blocked.com',
+            groupId: DEFAULT_GROUP_ID,
+            enabled: true,
+            matchMode: 'contains',
+          },
+        ],
+        rulesVersion: 9,
+      })
+    );
+
+    const { getTabController } = await import('../../../src/background/tabController');
+    await setBlockedTabState({
+      tabId: 7,
+      targetUrl: 'https://stale-blocked.com/focus',
+      blockedAt: Date.now(),
+      rulesVersion: 8,
+      blockedBy: {
+        filterId: 'stale-filter',
+        groupId: DEFAULT_GROUP_ID,
+      },
+    });
+
+    await getTabController().evaluateNavigation(
+      7,
+      `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://allowed.com/focus')}`
+    );
+
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
+      7,
+      { url: 'https://allowed.com/focus' },
+      expect.any(Function)
+    );
+    await expect(getBlockedTabState(7)).resolves.toBeUndefined();
+    await expect(getLastAllowedUrl(7)).resolves.toBe('https://allowed.com/focus');
+  });
+
+  it('returns freshly evaluated blocked tab state for the current blocked page target', async () => {
+    const chromeMock = getChromeMock();
+    chromeMock.storage.sync._data.set(
+      STORAGE_KEY,
+      createStorageData({
+        filters: [
+          {
+            id: 'fresh-filter',
+            pattern: 'fresh-blocked.com',
+            groupId: DEFAULT_GROUP_ID,
+            enabled: true,
+            matchMode: 'contains',
+          },
+        ],
+        rulesVersion: 10,
+      })
+    );
+
+    const { getTabController } = await import('../../../src/background/tabController');
+    await setBlockedTabState({
+      tabId: 10,
+      targetUrl: 'https://stale-blocked.com/focus',
+      blockedAt: Date.now(),
+      rulesVersion: 9,
+      blockedBy: {
+        filterId: 'stale-filter',
+        groupId: DEFAULT_GROUP_ID,
+      },
+    });
+
+    await expect(
+      getTabController().getFreshBlockedTabState(
+        10,
+        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://fresh-blocked.com/focus')}`
+      )
+    ).resolves.toEqual({
+      tabId: 10,
+      targetUrl: 'https://fresh-blocked.com/focus',
+      blockedAt: expect.any(Number),
+      rulesVersion: 10,
+      blockedBy: {
+        filterId: 'fresh-filter',
+        groupId: DEFAULT_GROUP_ID,
+      },
+    });
+  });
+
   it('reconciles open tabs after storage changes', async () => {
     const chromeMock = getChromeMock();
     chromeMock.tabs.query.mockImplementation(


### PR DESCRIPTION
## Summary

This PR lays groundwork for the warning-mode and group-toggle follow-ups by making blocked-tab reconciliation compute a fresh answer from the current blocked-page target and current rules.

## What changed

- Prefer the target encoded in the current blocked-page URL over older `BlockedTabState` session data.
- Add `getFreshBlockedTabState()` so future blocked-page UI work can ask background for a freshly evaluated state instead of trusting URL params or stale session records.
- Centralize blocked-tab state refresh so allowed targets clear stale state and blocked targets rewrite session state with the current `rulesVersion` and matching filter metadata.
- Preserve existing direct blocked-page behavior: a manually opened blocked page without session state is not auto-restored just because its target is currently allowed.

## Why

#78 and #91 both point at the same class of problem: UI/config state and background blocked-tab/session state can drift. This change makes the background path safer for future PRs to build on by ensuring blocked-tab state is reconciled from the current target before it is consumed.

## Validation

- `npm.cmd run lint` passed outside the sandbox path issue
- `npm.cmd run typecheck` passed
- `npm.cmd run typecheck:test` passed
- `npm.cmd run test:unit` passed, 135 tests
- `npm.cmd run test:e2e` passed, 35 tests
- `npm.cmd run format:check` still reports the repo-wide existing 62-file formatting/line-ending issue
- `git diff --check` passed