### PR TITLE
Expose blocked tab state to blocked page

### DIFF
--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -4,7 +4,12 @@
  */
 
 import { loadData } from '../../shared/api/storage';
-import { isCheckUrlMessage, isGetDataMessage, isGoBackActiveTabMessage } from '../../shared/types';
+import {
+  isCheckUrlMessage,
+  isGetBlockedPageStateMessage,
+  isGetDataMessage,
+  isGoBackActiveTabMessage,
+} from '../../shared/types';
 import { getTabController } from '../tabController';
 
 /**
@@ -36,6 +41,11 @@ export function handleMessage(
     return true;
   }
 
+  if (isGetBlockedPageStateMessage(message)) {
+    void handleGetBlockedPageState(sender, sendResponse);
+    return true;
+  }
+
   return false;
 }
 
@@ -54,4 +64,17 @@ async function handleCheckUrl(
 
 async function handleGoBackActiveTab(sendResponse: (response: unknown) => void): Promise<void> {
   sendResponse({ restored: await getTabController().goBackFromActiveTab() });
+}
+
+async function handleGetBlockedPageState(
+  sender: chrome.runtime.MessageSender,
+  sendResponse: (response: unknown) => void
+): Promise<void> {
+  const senderTabId = sender.tab?.id;
+  if (typeof senderTabId !== 'number') {
+    sendResponse({ status: 'unavailable' });
+    return;
+  }
+
+  sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
 }

--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -8,7 +8,11 @@ import {
 import { getActiveTab, queryTabs, updateTabUrl } from '../shared/api/tabs';
 import { getExtensionUrl } from '../shared/api/runtime';
 import { PAGES } from '../shared/constants';
-import { STORAGE_KEY, type BlockedTabState } from '../shared/types';
+import {
+  STORAGE_KEY,
+  type BlockedTabState,
+  type GetBlockedPageStateResponse,
+} from '../shared/types';
 import { isInternalUrl, type FilterDecision } from '../shared/utils';
 import { getRulesProvider, type CurrentRules, type RulesProvider } from './rulesProvider';
 
@@ -99,6 +103,27 @@ class TabController {
     }
 
     return this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+  }
+
+  async getFreshBlockedPageState(
+    tabId: number,
+    blockedPageUrl?: string
+  ): Promise<GetBlockedPageStateResponse> {
+    if (!Number.isInteger(tabId)) {
+      return { status: 'unavailable' };
+    }
+
+    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
+    if (!resolvedTarget) {
+      return { status: 'unavailable' };
+    }
+
+    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+    if (state) {
+      return { status: 'blocked', state };
+    }
+
+    return { status: 'allowed', targetUrl: resolvedTarget.targetUrl };
   }
 
   async reconcileAllOpenTabs(): Promise<void> {

--- a/src/blocked/index.ts
+++ b/src/blocked/index.ts
@@ -4,14 +4,22 @@
  */
 
 import { openOptionsPage } from '../shared/api/runtime';
-import { MessageType, type GoBackActiveTabResponse } from '../shared/types';
+import {
+  MessageType,
+  type GetBlockedPageStateResponse,
+  type GoBackActiveTabResponse,
+} from '../shared/types';
 import { getElementByIdOrNull } from '../shared/utils/dom';
+
+interface BlockedPageState {
+  readonly targetUrl: string;
+}
 
 /**
  * Initialize blocked page
  */
 async function init(): Promise<void> {
-  renderBlockedUrl();
+  renderBlockedUrl(await getBlockedPageState());
 
   const goBackButton = getElementByIdOrNull('go-back');
   goBackButton?.addEventListener('click', () => {
@@ -29,6 +37,60 @@ async function init(): Promise<void> {
   });
 }
 
+async function getBlockedPageState(): Promise<BlockedPageState> {
+  const fallbackState = getFallbackBlockedPageState();
+
+  try {
+    const response = (await chrome.runtime.sendMessage({
+      type: MessageType.GET_BLOCKED_PAGE_STATE,
+    })) as GetBlockedPageStateResponse;
+
+    if (!isBlockedPageStateResponse(response)) {
+      return fallbackState;
+    }
+
+    if (response.status === 'blocked') {
+      return { targetUrl: response.state.targetUrl };
+    }
+
+    if (response.status === 'allowed') {
+      return { targetUrl: response.targetUrl };
+    }
+  } catch (error: unknown) {
+    console.warn('[Teichos] Failed to load blocked tab state:', error);
+  }
+
+  return fallbackState;
+}
+
+function getFallbackBlockedPageState(): BlockedPageState {
+  const urlParams = new URLSearchParams(window.location.search);
+  return { targetUrl: urlParams.get('url') ?? 'Unknown URL' };
+}
+
+function isBlockedPageStateResponse(response: unknown): response is GetBlockedPageStateResponse {
+  if (!response || typeof response !== 'object' || !('status' in response)) {
+    return false;
+  }
+
+  if (response.status === 'unavailable') {
+    return true;
+  }
+
+  if (response.status === 'allowed') {
+    return 'targetUrl' in response && typeof response.targetUrl === 'string';
+  }
+
+  return (
+    response.status === 'blocked' &&
+    'state' in response &&
+    typeof response.state === 'object' &&
+    response.state !== null &&
+    'targetUrl' in response.state &&
+    typeof response.state.targetUrl === 'string'
+  );
+}
+
 async function handleGoBack(): Promise<void> {
   const response = (await chrome.runtime.sendMessage({
     type: MessageType.GO_BACK_ACTIVE_TAB,
@@ -39,11 +101,10 @@ async function handleGoBack(): Promise<void> {
   }
 }
 
-function renderBlockedUrl(): void {
-  const urlParams = new URLSearchParams(window.location.search);
+function renderBlockedUrl(state: BlockedPageState): void {
   const blockedUrlElement = getElementByIdOrNull('blocked-url');
   if (blockedUrlElement) {
-    blockedUrlElement.textContent = urlParams.get('url') ?? 'Unknown URL';
+    blockedUrlElement.textContent = state.targetUrl;
   }
 }
 

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -3,7 +3,7 @@
  * Uses discriminated unions for type-safe message handling
  */
 
-import type { Filter, StorageData } from './storage';
+import type { BlockedTabState, Filter, StorageData } from './storage';
 
 // Message types enum for discriminated union
 export const MessageType = {
@@ -11,6 +11,7 @@ export const MessageType = {
   DATA_UPDATED: 'DATA_UPDATED',
   CHECK_URL: 'CHECK_URL',
   URL_BLOCKED: 'URL_BLOCKED',
+  GET_BLOCKED_PAGE_STATE: 'GET_BLOCKED_PAGE_STATE',
   GO_BACK_ACTIVE_TAB: 'GO_BACK_ACTIVE_TAB',
   CLOSE_INFO_PANEL: 'CLOSE_INFO_PANEL',
 } as const;
@@ -31,6 +32,10 @@ export interface GoBackActiveTabMessage {
   readonly type: typeof MessageType.GO_BACK_ACTIVE_TAB;
 }
 
+export interface GetBlockedPageStateMessage {
+  readonly type: typeof MessageType.GET_BLOCKED_PAGE_STATE;
+}
+
 // Response messages
 export interface GetDataResponse {
   readonly success: true;
@@ -44,6 +49,19 @@ export interface CheckUrlResponse {
 export interface GoBackActiveTabResponse {
   readonly restored: boolean;
 }
+
+export type GetBlockedPageStateResponse =
+  | {
+      readonly status: 'blocked';
+      readonly state: BlockedTabState;
+    }
+  | {
+      readonly status: 'allowed';
+      readonly targetUrl: string;
+    }
+  | {
+      readonly status: 'unavailable';
+    };
 
 // Notification messages (broadcast)
 export interface DataUpdatedMessage {
@@ -66,6 +84,7 @@ export type ExtensionMessage =
   | GetDataMessage
   | CheckUrlMessage
   | GoBackActiveTabMessage
+  | GetBlockedPageStateMessage
   | DataUpdatedMessage
   | UrlBlockedMessage
   | CloseInfoPanelMessage;
@@ -77,7 +96,9 @@ export type MessageResponse<T extends ExtensionMessage> = T extends GetDataMessa
     ? CheckUrlResponse
     : T extends GoBackActiveTabMessage
       ? GoBackActiveTabResponse
-      : undefined;
+      : T extends GetBlockedPageStateMessage
+        ? GetBlockedPageStateResponse
+        : undefined;
 
 // Type guards for message validation
 export function isGetDataMessage(msg: unknown): msg is GetDataMessage {
@@ -103,6 +124,15 @@ export function isGoBackActiveTabMessage(msg: unknown): msg is GoBackActiveTabMe
     msg !== null &&
     'type' in msg &&
     msg.type === MessageType.GO_BACK_ACTIVE_TAB
+  );
+}
+
+export function isGetBlockedPageStateMessage(msg: unknown): msg is GetBlockedPageStateMessage {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    'type' in msg &&
+    msg.type === MessageType.GET_BLOCKED_PAGE_STATE
   );
 }
 

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures';
-import { captureScreenshot } from './helpers';
+import { captureScreenshot, createStorageData, defaultGroup, seedStorage } from './helpers';
 import { PAGES } from '../../src/shared/constants';
 
 test('go back restores the last allowed url', async ({
@@ -48,6 +48,55 @@ test('opens settings from the blocked page', async ({ context, extensionPage, pa
 
   await expect(optionsPage.getByRole('heading', { name: 'Teichos' })).toBeVisible();
   await expect.poll(() => new URL(optionsPage.url()).pathname).toBe(`/${PAGES.OPTIONS}`);
+});
+
+test('renders the blocked url from fresh tab state when query params are missing', async ({
+  extensionPage,
+  page,
+}) => {
+  const targetUrl = 'https://blocked-state.example.test/focus';
+
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await seedStorage(
+    page,
+    createStorageData({
+      filters: [
+        {
+          id: 'blocked-state-filter',
+          pattern: 'blocked-state.example.test',
+          groupId: defaultGroup.id,
+          enabled: true,
+          matchMode: 'contains',
+          description: 'Blocked State',
+        },
+      ],
+      rulesVersion: 1,
+    })
+  );
+  await page.evaluate(async (url) => {
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (typeof tab?.id !== 'number') {
+      return;
+    }
+
+    await chrome.storage.session.set({
+      [`blocked_tab_state_${tab.id}`]: {
+        tabId: tab.id,
+        targetUrl: url,
+        blockedAt: Date.now(),
+        rulesVersion: 1,
+        blockedBy: {
+          filterId: 'blocked-state-filter',
+          groupId: 'default-24x7',
+        },
+      },
+    });
+  }, targetUrl);
+
+  await page.goto(extensionPage(PAGES.BLOCKED));
+
+  await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+  await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
 });
 
 test('handles missing or malformed blocked urls and no-op go back safely', async ({

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getUrlDecision: vi.fn(),
+  getFreshBlockedPageState: vi.fn(),
   goBackFromActiveTab: vi.fn(),
   loadData: vi.fn(),
 }));
@@ -9,9 +10,11 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../../src/background/tabController', () => ({
   getTabController: (): {
     getUrlDecision: typeof mocks.getUrlDecision;
+    getFreshBlockedPageState: typeof mocks.getFreshBlockedPageState;
     goBackFromActiveTab: typeof mocks.goBackFromActiveTab;
   } => ({
     getUrlDecision: mocks.getUrlDecision,
+    getFreshBlockedPageState: mocks.getFreshBlockedPageState,
     goBackFromActiveTab: mocks.goBackFromActiveTab,
   }),
 }));
@@ -36,6 +39,7 @@ describe('handleMessage', () => {
   beforeEach(() => {
     mocks.loadData.mockResolvedValue(defaultData);
     mocks.getUrlDecision.mockResolvedValue({ action: 'allow', reason: 'no-match' });
+    mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'unavailable' });
     mocks.goBackFromActiveTab.mockResolvedValue(false);
   });
 
@@ -96,6 +100,78 @@ describe('handleMessage', () => {
 
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith({ restored: true });
+    });
+  });
+
+  it('responds to blocked-page state requests', async () => {
+    const blockedState = {
+      tabId: 7,
+      targetUrl: 'https://blocked.com/focus',
+      blockedAt: 1234,
+      rulesVersion: 2,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: DEFAULT_GROUP_ID,
+      },
+    };
+    mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'blocked', state: blockedState });
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE },
+        {
+          id: 'test-extension-id',
+          tab: {
+            id: 7,
+            url: 'chrome-extension://test-extension-id/src/blocked/index.html',
+          } as chrome.tabs.Tab,
+        },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ status: 'blocked', state: blockedState });
+    });
+    expect(mocks.getFreshBlockedPageState).toHaveBeenCalledWith(
+      7,
+      'chrome-extension://test-extension-id/src/blocked/index.html'
+    );
+  });
+
+  it('returns unavailable blocked-page state when the sender tab is unavailable', async () => {
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE },
+        { id: 'test-extension-id' },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ status: 'unavailable' });
+    });
+    expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+  });
+
+  it('forwards allowed blocked-page state responses', async () => {
+    const response = { status: 'allowed', targetUrl: 'https://allowed.com/focus' };
+    mocks.getFreshBlockedPageState.mockResolvedValue(response);
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE },
+        { id: 'test-extension-id', tab: { id: 8 } as chrome.tabs.Tab },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(response);
     });
   });
 

--- a/test/unit/shared/messages.test.ts
+++ b/test/unit/shared/messages.test.ts
@@ -5,6 +5,7 @@ import {
   isCheckUrlMessage,
   isCloseInfoPanelMessage,
   isDataUpdatedMessage,
+  isGetBlockedPageStateMessage,
   isGetDataMessage,
   isGoBackActiveTabMessage,
   isUrlBlockedMessage,
@@ -19,6 +20,7 @@ describe('shared/types/messages', () => {
     );
     expect(isCheckUrlMessage({ type: MessageType.CHECK_URL, url: 42 })).toBe(false);
     expect(isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB })).toBe(true);
+    expect(isGetBlockedPageStateMessage({ type: MessageType.GET_BLOCKED_PAGE_STATE })).toBe(true);
   });
 
   it('recognizes broadcast messages', () => {


### PR DESCRIPTION
## Summary

This is the narrow follow-up to #93. It gives the blocked page a background state channel so future warning-mode work can render from fresh blocked-tab state instead of relying only on URL query params.

## What changed

- Added a `GET_BLOCKED_TAB_STATE` runtime message and typed response.
- Routed that message through `TabController.getFreshBlockedTabState(sender.tab.id, sender.tab.url)`.
- Updated the blocked page to render the target URL from fresh background state when available, falling back to query params only when state is unavailable.
- Added unit coverage for the message guard and background handler.
- Added e2e coverage for a blocked page with no `url` query param rendering from session/background state.

## Why

#93 made blocked-tab reconciliation fresher in the background, but the blocked page still rendered only from query params. #91 will need this state channel before Warning/Continue can be reliable, and this keeps that plumbing separate from warning semantics.

## Validation

- `npm.cmd run lint` passed outside the sandbox path issue
- `npm.cmd run typecheck` passed
- `npm.cmd run typecheck:test` passed
- `npm.cmd run test:unit` passed, 137 tests
- `npm.cmd run test:e2e` passed, 36 tests
- `npm.cmd run format:check` still reports the existing repo-wide formatting/line-ending issue, now 58 files
- `git diff --check` passed