### PR TITLE
Show filter details on block page

### DIFF
--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -21,8 +21,9 @@ export function handleMessage(
   sender: chrome.runtime.MessageSender,
   sendResponse: (response: unknown) => void
 ): boolean {
-  // Validate sender is from our extension
-  if (sender.id !== chrome.runtime.id) {
+  // Validate sender is from our extension. Extension pages may provide a URL
+  // without an id, depending on the runtime context.
+  if (!isInternalSender(sender)) {
     return false;
   }
 
@@ -78,4 +79,16 @@ async function handleGetBlockedPageState(
   }
 
   sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
+}
+
+function isInternalSender(sender: chrome.runtime.MessageSender): boolean {
+  if (sender.id === chrome.runtime.id) {
+    return true;
+  }
+
+  if (!sender.url) {
+    return false;
+  }
+
+  return sender.url.startsWith(chrome.runtime.getURL(''));
 }

--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -42,7 +42,7 @@ export function handleMessage(
   }
 
   if (isGetBlockedPageStateMessage(message)) {
-    void handleGetBlockedPageState(sender, sendResponse);
+    void handleGetBlockedPageState(message.blockId, sender, sendResponse);
     return true;
   }
 
@@ -67,12 +67,13 @@ async function handleGoBackActiveTab(sendResponse: (response: unknown) => void):
 }
 
 async function handleGetBlockedPageState(
+  blockId: string | undefined,
   sender: chrome.runtime.MessageSender,
   sendResponse: (response: unknown) => void
 ): Promise<void> {
   const senderTabId = sender.tab?.id;
   if (typeof senderTabId !== 'number') {
-    sendResponse({ status: 'unavailable' });
+    sendResponse(await getTabController().getBlockedPageStateByBlockId(blockId));
     return;
   }
 

--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -1,7 +1,10 @@
 import {
   clearBlockedTabState,
+  clearBlockedPageState,
+  getBlockedPageState,
   getBlockedTabState,
   getLastAllowedUrl,
+  setBlockedPageState,
   setBlockedTabState,
   setLastAllowedUrl,
 } from '../shared/api/session';
@@ -10,15 +13,24 @@ import { getExtensionUrl } from '../shared/api/runtime';
 import { PAGES } from '../shared/constants';
 import {
   STORAGE_KEY,
+  type BlockedPageState,
   type BlockedTabState,
+  type Filter,
   type GetBlockedPageStateResponse,
+  type StorageData,
 } from '../shared/types';
 import { isInternalUrl, type FilterDecision } from '../shared/utils';
 import { getRulesProvider, type CurrentRules, type RulesProvider } from './rulesProvider';
 
 interface ResolvedBlockedTarget {
   readonly targetUrl: string;
+  readonly blockId?: string;
   readonly hasSessionState: boolean;
+}
+
+interface BlockedStateResult {
+  readonly tabState: BlockedTabState;
+  readonly pageState: BlockedPageState;
 }
 
 class TabController {
@@ -60,7 +72,7 @@ class TabController {
     const decision = rules.engine.evaluate(url);
 
     if (decision.action === 'block') {
-      await this.blockTab(tabId, url, decision, rules.data.rulesVersion);
+      await this.blockTab(tabId, url, decision, rules);
       return;
     }
 
@@ -79,8 +91,8 @@ class TabController {
     }
 
     const rules = await this.getRules();
-    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
-    if (state) {
+    const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
+    if (decision.action === 'block') {
       return false;
     }
 
@@ -102,13 +114,19 @@ class TabController {
       return undefined;
     }
 
-    return this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+    return state?.tabState;
   }
 
   async getFreshBlockedPageState(
     tabId: number,
     blockedPageUrl?: string
   ): Promise<GetBlockedPageStateResponse> {
+    const blockId = parseBlockedPageBlockId(blockedPageUrl);
+    if (blockId) {
+      return this.getBlockedPageStateByBlockId(blockId);
+    }
+
     if (!Number.isInteger(tabId)) {
       return { status: 'unavailable' };
     }
@@ -120,10 +138,32 @@ class TabController {
 
     const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
     if (state) {
-      return { status: 'blocked', state };
+      return { status: 'blocked', state: state.pageState };
     }
 
     return { status: 'allowed', targetUrl: resolvedTarget.targetUrl };
+  }
+
+  async getBlockedPageStateByBlockId(
+    blockId: string | undefined
+  ): Promise<GetBlockedPageStateResponse> {
+    if (!blockId) {
+      return { status: 'unavailable' };
+    }
+
+    const pageState = await getBlockedPageState(blockId);
+    if (!pageState) {
+      return { status: 'unavailable' };
+    }
+
+    const rules = await this.getRules();
+    const decision = rules.engine.evaluate(pageState.targetUrl);
+    if (decision.action !== 'block') {
+      await this.allowTab(pageState.tabId, pageState.targetUrl);
+      return { status: 'allowed', targetUrl: pageState.targetUrl };
+    }
+
+    return { status: 'blocked', state: pageState };
   }
 
   async reconcileAllOpenTabs(): Promise<void> {
@@ -187,8 +227,8 @@ class TabController {
     }
 
     const rules = await this.getRules();
-    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
-    if (!state) {
+    const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
+    if (decision.action !== 'block') {
       if (resolvedTarget.hasSessionState) {
         await updateTabUrl(tabId, resolvedTarget.targetUrl);
         await this.allowTab(tabId, resolvedTarget.targetUrl);
@@ -201,10 +241,10 @@ class TabController {
     tabId: number,
     url: string,
     decision: Extract<FilterDecision, { action: 'block' }>,
-    rulesVersion: number
+    rules: CurrentRules
   ): Promise<void> {
-    await this.setBlockedState(tabId, url, decision, rulesVersion);
-    const blockedUrl = `${getExtensionUrl(PAGES.BLOCKED)}?url=${encodeURIComponent(url)}`;
+    const state = await this.setBlockedState(tabId, url, decision, rules.data);
+    const blockedUrl = `${getExtensionUrl(PAGES.BLOCKED)}?blockId=${encodeURIComponent(state.tabState.blockId)}`;
     await updateTabUrl(tabId, blockedUrl);
   }
 
@@ -216,21 +256,34 @@ class TabController {
     tabId: number,
     targetUrl: string,
     decision: Extract<FilterDecision, { action: 'block' }>,
-    rulesVersion: number
-  ): Promise<BlockedTabState> {
-    const state: BlockedTabState = {
+    data: StorageData
+  ): Promise<BlockedStateResult> {
+    const existingState = await getBlockedTabState(tabId);
+    if (existingState) {
+      await clearBlockedPageState(existingState.blockId);
+    }
+
+    const blockId = createBlockId();
+    const tabState: BlockedTabState = {
+      blockId,
       tabId,
       targetUrl,
       blockedAt: Date.now(),
-      rulesVersion,
+      rulesVersion: data.rulesVersion,
       blockedBy: {
         filterId: decision.filterId,
         groupId: decision.groupId,
       },
     };
+    const filter = data.filters.find((entry) => entry.id === decision.filterId);
+    const pageState: BlockedPageState = {
+      ...tabState,
+      filter: createFilterSnapshot(filter, decision.filterId),
+      group: data.groups.find((entry) => entry.id === decision.groupId),
+    };
 
-    await setBlockedTabState(state);
-    return state;
+    await Promise.all([setBlockedTabState(tabState), setBlockedPageState(pageState)]);
+    return { tabState, pageState };
   }
 
   private async resolveBlockedTarget(
@@ -238,16 +291,26 @@ class TabController {
     blockedPageUrl?: string
   ): Promise<ResolvedBlockedTarget | undefined> {
     const existingState = await getBlockedTabState(tabId);
-    const fallbackTargetUrl = parseBlockedTargetUrl(blockedPageUrl);
-    if (fallbackTargetUrl) {
+    const blockId = parseBlockedPageBlockId(blockedPageUrl);
+    if (blockId) {
+      const pageState = await getBlockedPageState(blockId);
+      if (!pageState) {
+        return undefined;
+      }
+
       return {
-        targetUrl: fallbackTargetUrl,
-        hasSessionState: Boolean(existingState),
+        targetUrl: pageState.targetUrl,
+        blockId,
+        hasSessionState: true,
       };
     }
 
     return existingState
-      ? { targetUrl: existingState.targetUrl, hasSessionState: true }
+      ? {
+          targetUrl: existingState.targetUrl,
+          blockId: existingState.blockId,
+          hasSessionState: true,
+        }
       : undefined;
   }
 
@@ -255,7 +318,7 @@ class TabController {
     tabId: number,
     targetUrl: string,
     currentRules?: CurrentRules
-  ): Promise<BlockedTabState | undefined> {
+  ): Promise<BlockedStateResult | undefined> {
     const rules = currentRules ?? (await this.getRules());
     const decision = rules.engine.evaluate(targetUrl);
     if (decision.action !== 'block') {
@@ -263,7 +326,7 @@ class TabController {
       return undefined;
     }
 
-    return this.setBlockedState(tabId, targetUrl, decision, rules.data.rulesVersion);
+    return this.setBlockedState(tabId, targetUrl, decision, rules.data);
   }
 
   private queueReconcile(): void {
@@ -282,7 +345,7 @@ class TabController {
   }
 }
 
-function parseBlockedTargetUrl(tabUrl: string | undefined): string | null {
+function parseBlockedPageBlockId(tabUrl: string | undefined): string | null {
   if (!tabUrl) {
     return null;
   }
@@ -293,19 +356,28 @@ function parseBlockedTargetUrl(tabUrl: string | undefined): string | null {
   }
 
   try {
-    const blockedTargetUrl = new URL(tabUrl).searchParams.get('url');
-    if (
-      !blockedTargetUrl ||
-      isInternalUrl(blockedTargetUrl) ||
-      blockedTargetUrl.startsWith(blockedPageUrl)
-    ) {
-      return null;
-    }
-
-    return blockedTargetUrl;
+    return new URL(tabUrl).searchParams.get('blockId');
   } catch {
     return null;
   }
+}
+
+function createBlockId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+function createFilterSnapshot(
+  filter: Filter | undefined,
+  fallbackFilterId: string
+): BlockedPageState['filter'] {
+  return {
+    id: filter?.id ?? fallbackFilterId,
+    pattern: filter?.pattern ?? fallbackFilterId,
+    matchMode: filter?.matchMode ?? 'contains',
+    ...(filter?.description ? { description: filter.description } : {}),
+  };
 }
 
 const tabController = new TabController(getRulesProvider());

--- a/src/blocked/index.html
+++ b/src/blocked/index.html
@@ -12,6 +12,35 @@
       <h1>Page Blocked</h1>
       <p>This page has been blocked by Teichos based on your filter settings.</p>
       <div class="url" id="blocked-url" role="status" aria-label="Blocked URL"></div>
+      <section
+        class="responsible-filter"
+        id="responsible-filter"
+        aria-label="Responsible filter"
+        hidden
+      >
+        <div class="responsible-filter-header">
+          <span class="responsible-filter-kicker">Blocked by</span>
+          <h2 id="responsible-filter-name"></h2>
+        </div>
+        <dl class="detail-grid">
+          <div class="detail-item">
+            <dt>Pattern</dt>
+            <dd id="responsible-filter-pattern"></dd>
+          </div>
+          <div class="detail-item">
+            <dt>Match</dt>
+            <dd id="responsible-filter-match"></dd>
+          </div>
+          <div class="detail-item">
+            <dt>Group</dt>
+            <dd id="responsible-filter-group"></dd>
+          </div>
+          <div class="detail-item">
+            <dt>Schedule</dt>
+            <dd id="responsible-filter-schedule"></dd>
+          </div>
+        </dl>
+      </section>
       <div class="actions">
         <button class="button" id="go-back" type="button">Go Back</button>
         <button class="button secondary" id="open-options" type="button">Manage Filters</button>

--- a/src/blocked/index.ts
+++ b/src/blocked/index.ts
@@ -6,20 +6,26 @@
 import { openOptionsPage } from '../shared/api/runtime';
 import {
   MessageType,
+  type BlockedPageState,
+  type FilterMatchMode,
   type GetBlockedPageStateResponse,
   type GoBackActiveTabResponse,
 } from '../shared/types';
 import { getElementByIdOrNull } from '../shared/utils/dom';
+import { formatGroupScheduleSummary } from '../shared/utils/schedules';
 
-interface BlockedPageState {
+interface BlockedPageViewModel {
   readonly targetUrl: string;
+  readonly state?: BlockedPageState;
 }
 
 /**
  * Initialize blocked page
  */
 async function init(): Promise<void> {
-  renderBlockedUrl(await getBlockedPageState());
+  const state = await getBlockedPageState();
+  renderBlockedUrl(state);
+  renderResponsibleFilter(state);
 
   const goBackButton = getElementByIdOrNull('go-back');
   goBackButton?.addEventListener('click', () => {
@@ -37,20 +43,22 @@ async function init(): Promise<void> {
   });
 }
 
-async function getBlockedPageState(): Promise<BlockedPageState> {
-  const fallbackState = getFallbackBlockedPageState();
-
+async function getBlockedPageState(): Promise<BlockedPageViewModel> {
   try {
     const response = (await chrome.runtime.sendMessage({
       type: MessageType.GET_BLOCKED_PAGE_STATE,
+      blockId: getBlockedPageBlockId(),
     })) as GetBlockedPageStateResponse;
 
     if (!isBlockedPageStateResponse(response)) {
-      return fallbackState;
+      return getUnavailableBlockedPageState();
     }
 
     if (response.status === 'blocked') {
-      return { targetUrl: response.state.targetUrl };
+      return {
+        targetUrl: response.state.targetUrl,
+        state: response.state,
+      };
     }
 
     if (response.status === 'allowed') {
@@ -60,12 +68,15 @@ async function getBlockedPageState(): Promise<BlockedPageState> {
     console.warn('[Teichos] Failed to load blocked tab state:', error);
   }
 
-  return fallbackState;
+  return getUnavailableBlockedPageState();
 }
 
-function getFallbackBlockedPageState(): BlockedPageState {
-  const urlParams = new URLSearchParams(window.location.search);
-  return { targetUrl: urlParams.get('url') ?? 'Unknown URL' };
+function getBlockedPageBlockId(): string | undefined {
+  return new URLSearchParams(window.location.search).get('blockId') ?? undefined;
+}
+
+function getUnavailableBlockedPageState(): BlockedPageViewModel {
+  return { targetUrl: 'Block details unavailable' };
 }
 
 function isBlockedPageStateResponse(response: unknown): response is GetBlockedPageStateResponse {
@@ -87,7 +98,12 @@ function isBlockedPageStateResponse(response: unknown): response is GetBlockedPa
     typeof response.state === 'object' &&
     response.state !== null &&
     'targetUrl' in response.state &&
-    typeof response.state.targetUrl === 'string'
+    typeof response.state.targetUrl === 'string' &&
+    'filter' in response.state &&
+    typeof response.state.filter === 'object' &&
+    response.state.filter !== null &&
+    'pattern' in response.state.filter &&
+    typeof response.state.filter.pattern === 'string'
   );
 }
 
@@ -101,11 +117,57 @@ async function handleGoBack(): Promise<void> {
   }
 }
 
-function renderBlockedUrl(state: BlockedPageState): void {
+function renderBlockedUrl(state: BlockedPageViewModel): void {
   const blockedUrlElement = getElementByIdOrNull('blocked-url');
   if (blockedUrlElement) {
     blockedUrlElement.textContent = state.targetUrl;
   }
+}
+
+function renderResponsibleFilter(state: BlockedPageViewModel): void {
+  const detailSection = getElementByIdOrNull<HTMLElement>('responsible-filter');
+  if (!detailSection || !state.state) {
+    return;
+  }
+
+  setText('responsible-filter-name', getFilterDisplayName(state.state));
+  setText('responsible-filter-pattern', state.state.filter.pattern);
+  setText('responsible-filter-match', formatMatchMode(state.state.filter.matchMode));
+  setText('responsible-filter-group', state.state.group?.name ?? 'Unknown group');
+  setText(
+    'responsible-filter-schedule',
+    state.state.group ? formatGroupScheduleSummary(state.state.group) : 'Unavailable'
+  );
+
+  detailSection.hidden = false;
+}
+
+function setText(elementId: string, value: string): void {
+  const element = getElementByIdOrNull(elementId);
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function getFilterDisplayName(state: BlockedPageState): string {
+  const name = state.filter.description?.trim();
+  if (name) {
+    return name;
+  }
+
+  return state.filter.pattern;
+}
+
+function formatMatchMode(matchMode: FilterMatchMode): string {
+  if (matchMode === 'regex') {
+    return 'Regular expression';
+  }
+
+  if (matchMode === 'exact') {
+    return 'Exact URL';
+  }
+
+  return 'Contains text';
 }
 
 // Initialize on load

--- a/src/blocked/styles/blocked.css
+++ b/src/blocked/styles/blocked.css
@@ -5,8 +5,10 @@
 :root {
   color-scheme: light;
   --text-2xl: 2.25rem;
+  --text-xl: 1.35rem;
   --text-lg: 1.1rem;
   --text-md: 0.98rem;
+  --text-sm: 0.82rem;
   --bg-glow-primary: rgba(172, 210, 246, 0.3);
   --bg-glow-secondary: rgba(102, 109, 220, 0.22);
   --bg-gradient-start: #4e4cd3;
@@ -15,6 +17,10 @@
   --text-on-bg: #f7f8ff;
   --url-bg: rgba(255, 255, 255, 0.2);
   --url-border: rgba(255, 255, 255, 0.28);
+  --panel-bg: rgba(255, 255, 255, 0.18);
+  --panel-border: rgba(255, 255, 255, 0.24);
+  --panel-divider: rgba(255, 255, 255, 0.18);
+  --muted-text: rgba(247, 248, 255, 0.72);
   --button-bg: #f8fbff;
   --button-text: #4e4cd3;
   --button-bg-hover: #ecefff;
@@ -72,9 +78,69 @@ p {
   padding: 1rem;
   border-radius: 8px;
   word-break: break-all;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   font-family: monospace;
   font-size: var(--text-md);
+}
+
+.responsible-filter {
+  text-align: left;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 18px 52px rgba(24, 27, 72, 0.18);
+}
+
+.responsible-filter-header {
+  margin-bottom: 0.9rem;
+}
+
+.responsible-filter-kicker {
+  display: block;
+  color: var(--muted-text);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h2 {
+  font-size: var(--text-xl);
+  line-height: 1.25;
+  margin: 0.15rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  margin: 0;
+  border-top: 1px solid var(--panel-divider);
+}
+
+.detail-item {
+  min-width: 0;
+  padding: 0.85rem 0.9rem 0 0;
+}
+
+.detail-item dt {
+  color: var(--muted-text);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  margin-bottom: 0.2rem;
+}
+
+.detail-item dd {
+  margin: 0;
+  font-size: var(--text-md);
+  overflow-wrap: anywhere;
+}
+
+.detail-item:first-child dd {
+  font-family: monospace;
 }
 
 .actions {
@@ -129,6 +195,10 @@ p {
     --text-on-bg: #f0f2ff;
     --url-bg: rgba(12, 22, 39, 0.44);
     --url-border: rgba(173, 203, 244, 0.18);
+    --panel-bg: rgba(12, 22, 39, 0.34);
+    --panel-border: rgba(173, 203, 244, 0.2);
+    --panel-divider: rgba(173, 203, 244, 0.16);
+    --muted-text: rgba(240, 242, 255, 0.72);
     --button-bg: #ddecff;
     --button-text: #3a32a9;
     --button-bg-hover: #cfd8ff;
@@ -136,5 +206,27 @@ p {
     --button-alt-bg-hover: rgba(24, 27, 72, 0.66);
     --button-alt-text: #f0f2ff;
     --focus-ring: rgba(228, 232, 255, 0.9);
+  }
+}
+
+@media (max-width: 520px) {
+  body {
+    align-items: flex-start;
+  }
+
+  .container {
+    padding: 1.5rem;
+  }
+
+  .icon {
+    font-size: 64px;
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .button {
+    width: 100%;
   }
 }

--- a/src/shared/api/session.ts
+++ b/src/shared/api/session.ts
@@ -2,11 +2,20 @@
  * Typed wrapper for chrome.storage.session API
  */
 
-import type { BlockedTabState, SnoozeState } from '../types';
+import type {
+  BlockedFilterSnapshot,
+  BlockedGroupSnapshot,
+  BlockedPageState,
+  BlockedTabState,
+  FilterMatchMode,
+  SnoozeState,
+  TimeSchedule,
+} from '../types';
 
 const LAST_ALLOWED_URL_KEY_PREFIX = 'last_allowed_url_' as const;
 const SNOOZE_OVERRIDE_KEY = 'snooze_override' as const;
 const BLOCKED_TAB_STATE_KEY_PREFIX = 'blocked_tab_state_' as const;
+const BLOCKED_PAGE_STATE_KEY_PREFIX = 'blocked_page_state_' as const;
 
 function lastAllowedUrlKey(tabId: number): string {
   return `${LAST_ALLOWED_URL_KEY_PREFIX}${tabId}`;
@@ -14,6 +23,10 @@ function lastAllowedUrlKey(tabId: number): string {
 
 function blockedTabStateKey(tabId: number): string {
   return `${BLOCKED_TAB_STATE_KEY_PREFIX}${tabId}`;
+}
+
+function blockedPageStateKey(blockId: string): string {
+  return `${BLOCKED_PAGE_STATE_KEY_PREFIX}${blockId}`;
 }
 
 /**
@@ -40,6 +53,7 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
 
   const candidate = value as Partial<BlockedTabState>;
   if (
+    typeof candidate.blockId !== 'string' ||
     typeof candidate.tabId !== 'number' ||
     typeof candidate.targetUrl !== 'string' ||
     typeof candidate.blockedAt !== 'number' ||
@@ -52,6 +66,7 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
   }
 
   return {
+    blockId: candidate.blockId,
     tabId: candidate.tabId,
     targetUrl: candidate.targetUrl,
     blockedAt: candidate.blockedAt,
@@ -74,7 +89,120 @@ export async function getBlockedTabState(tabId: number): Promise<BlockedTabState
 }
 
 export async function clearBlockedTabState(tabId: number): Promise<void> {
-  await chrome.storage.session.remove(blockedTabStateKey(tabId));
+  const existingState = await getBlockedTabState(tabId);
+  const keys = [blockedTabStateKey(tabId)];
+  if (existingState) {
+    keys.push(blockedPageStateKey(existingState.blockId));
+  }
+  await chrome.storage.session.remove(keys);
+}
+
+function isFilterMatchMode(value: unknown): value is FilterMatchMode {
+  return value === 'contains' || value === 'exact' || value === 'regex';
+}
+
+function normalizeBlockedFilterSnapshot(value: unknown): BlockedFilterSnapshot | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedFilterSnapshot>;
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.pattern !== 'string' ||
+    !isFilterMatchMode(candidate.matchMode)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: candidate.id,
+    pattern: candidate.pattern,
+    matchMode: candidate.matchMode,
+    ...(typeof candidate.description === 'string' ? { description: candidate.description } : {}),
+  };
+}
+
+function normalizeSchedule(value: unknown): TimeSchedule | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<TimeSchedule>;
+  if (
+    !Array.isArray(candidate.daysOfWeek) ||
+    !candidate.daysOfWeek.every((day) => typeof day === 'number') ||
+    typeof candidate.startTime !== 'string' ||
+    typeof candidate.endTime !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    daysOfWeek: candidate.daysOfWeek,
+    startTime: candidate.startTime,
+    endTime: candidate.endTime,
+  };
+}
+
+function normalizeBlockedGroupSnapshot(value: unknown): BlockedGroupSnapshot | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedGroupSnapshot>;
+  const schedules = Array.isArray(candidate.schedules)
+    ? candidate.schedules.map(normalizeSchedule)
+    : undefined;
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.name !== 'string' ||
+    typeof candidate.is24x7 !== 'boolean' ||
+    !schedules ||
+    schedules.some((schedule) => !schedule)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: candidate.id,
+    name: candidate.name,
+    is24x7: candidate.is24x7,
+    schedules: schedules.filter((schedule): schedule is TimeSchedule => Boolean(schedule)),
+  };
+}
+
+function normalizeBlockedPageState(value: unknown): BlockedPageState | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedPageState>;
+  const tabState = normalizeBlockedTabState(candidate);
+  const filter = normalizeBlockedFilterSnapshot(candidate.filter);
+  if (!tabState || !filter) {
+    return undefined;
+  }
+
+  return {
+    ...tabState,
+    filter,
+    group: normalizeBlockedGroupSnapshot(candidate.group),
+  };
+}
+
+export async function setBlockedPageState(state: BlockedPageState): Promise<void> {
+  await chrome.storage.session.set({ [blockedPageStateKey(state.blockId)]: state });
+}
+
+export async function getBlockedPageState(blockId: string): Promise<BlockedPageState | undefined> {
+  const key = blockedPageStateKey(blockId);
+  const result = await chrome.storage.session.get(key);
+  return normalizeBlockedPageState(result[key]);
+}
+
+export async function clearBlockedPageState(blockId: string): Promise<void> {
+  await chrome.storage.session.remove(blockedPageStateKey(blockId));
 }
 
 function normalizeSessionSnooze(value: unknown): SnoozeState | undefined {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -3,7 +3,7 @@
  * Uses discriminated unions for type-safe message handling
  */
 
-import type { BlockedTabState, Filter, StorageData } from './storage';
+import type { BlockedPageState, Filter, StorageData } from './storage';
 
 // Message types enum for discriminated union
 export const MessageType = {
@@ -34,6 +34,7 @@ export interface GoBackActiveTabMessage {
 
 export interface GetBlockedPageStateMessage {
   readonly type: typeof MessageType.GET_BLOCKED_PAGE_STATE;
+  readonly blockId?: string;
 }
 
 // Response messages
@@ -53,7 +54,7 @@ export interface GoBackActiveTabResponse {
 export type GetBlockedPageStateResponse =
   | {
       readonly status: 'blocked';
-      readonly state: BlockedTabState;
+      readonly state: BlockedPageState;
     }
   | {
       readonly status: 'allowed';
@@ -132,7 +133,8 @@ export function isGetBlockedPageStateMessage(msg: unknown): msg is GetBlockedPag
     typeof msg === 'object' &&
     msg !== null &&
     'type' in msg &&
-    msg.type === MessageType.GET_BLOCKED_PAGE_STATE
+    msg.type === MessageType.GET_BLOCKED_PAGE_STATE &&
+    (!('blockId' in msg) || typeof msg.blockId === 'string')
   );
 }
 

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -61,11 +61,32 @@ export interface BlockedBy {
 }
 
 export interface BlockedTabState {
+  readonly blockId: string;
   readonly tabId: number;
   readonly targetUrl: string;
   readonly blockedBy: BlockedBy;
   readonly blockedAt: number;
   readonly rulesVersion: number;
+}
+
+export interface BlockedFilterSnapshot {
+  readonly id: string;
+  readonly pattern: string;
+  readonly matchMode: FilterMatchMode;
+  readonly description?: string;
+}
+
+export type BlockedGroupSnapshot = FilterGroup;
+
+export interface BlockedPageState {
+  readonly blockId: string;
+  readonly tabId: number;
+  readonly targetUrl: string;
+  readonly blockedBy: BlockedBy;
+  readonly blockedAt: number;
+  readonly rulesVersion: number;
+  readonly filter: BlockedFilterSnapshot;
+  readonly group: BlockedGroupSnapshot | undefined;
 }
 
 /** Root storage schema */

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -18,13 +18,29 @@ test('go back restores the last allowed url', async ({
     });
   });
 
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent(blockedUrl)}`);
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await seedStorage(
+    page,
+    createStorageData({
+      filters: [
+        {
+          id: 'blocked-page-filter',
+          pattern: 'blocked.example.invalid',
+          groupId: defaultGroup.id,
+          enabled: true,
+          matchMode: 'contains',
+          description: 'Blocked Page',
+        },
+      ],
+    })
+  );
   await page.evaluate(async (url) => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (typeof tab?.id === 'number') {
       await chrome.storage.session.set({ [`last_allowed_url_${tab.id}`]: url });
     }
   }, allowedUrl);
+  await page.goto(blockedUrl).catch(() => undefined);
 
   await expect(page.getByLabel('Blocked URL')).toHaveText(blockedUrl);
   await captureScreenshot(page, testInfo, 'blocked-page.png');
@@ -37,9 +53,7 @@ test('go back restores the last allowed url', async ({
 });
 
 test('opens settings from the blocked page', async ({ context, extensionPage, page }) => {
-  await page.goto(
-    `${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent('https://blocked.example.invalid')}`
-  );
+  await page.goto(extensionPage(PAGES.BLOCKED));
 
   const optionsPagePromise = context.waitForEvent('page');
   await page.getByRole('button', { name: 'Manage Filters' }).click();
@@ -50,10 +64,7 @@ test('opens settings from the blocked page', async ({ context, extensionPage, pa
   await expect.poll(() => new URL(optionsPage.url()).pathname).toBe(`/${PAGES.OPTIONS}`);
 });
 
-test('renders the blocked url from fresh tab state when query params are missing', async ({
-  extensionPage,
-  page,
-}) => {
+test('renders the blocked url from block id state', async ({ extensionPage, page }) => {
   const targetUrl = 'https://blocked-state.example.test/focus';
 
   await page.goto(extensionPage(PAGES.OPTIONS));
@@ -81,6 +92,7 @@ test('renders the blocked url from fresh tab state when query params are missing
 
     await chrome.storage.session.set({
       [`blocked_tab_state_${tab.id}`]: {
+        blockId: 'manual-block',
         tabId: tab.id,
         targetUrl: url,
         blockedAt: Date.now(),
@@ -90,30 +102,55 @@ test('renders the blocked url from fresh tab state when query params are missing
           groupId: 'default-24x7',
         },
       },
+      'blocked_page_state_manual-block': {
+        blockId: 'manual-block',
+        tabId: tab.id,
+        targetUrl: url,
+        blockedAt: Date.now(),
+        rulesVersion: 1,
+        blockedBy: {
+          filterId: 'blocked-state-filter',
+          groupId: 'default-24x7',
+        },
+        filter: {
+          id: 'blocked-state-filter',
+          pattern: 'blocked-state.example.test',
+          matchMode: 'contains',
+          description: 'Blocked State',
+        },
+        group: {
+          id: 'default-24x7',
+          name: '24/7 (Always Active)',
+          schedules: [],
+          is24x7: true,
+        },
+      },
     });
   }, targetUrl);
 
-  await page.goto(extensionPage(PAGES.BLOCKED));
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?blockId=manual-block`);
 
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toContainText('Blocked State');
 });
 
-test('handles missing or malformed blocked urls and no-op go back safely', async ({
+test('handles missing or stale block ids and no-op go back safely', async ({
   extensionPage,
   page,
 }) => {
   await page.goto(extensionPage(PAGES.BLOCKED));
-  await expect(page.getByLabel('Blocked URL')).toHaveText('Unknown URL');
+  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
-  const missingUrlPage = page.url();
+  const missingBlockPage = page.url();
   await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect.poll(() => page.url()).toBe(missingUrlPage);
+  await expect.poll(() => page.url()).toBe(missingBlockPage);
 
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?url=%E0%A4%A`);
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?blockId=missing-block`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
-  const malformedUrlPage = page.url();
+  const staleBlockPage = page.url();
   await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect.poll(() => page.url()).toBe(malformedUrlPage);
+  await expect.poll(() => page.url()).toBe(staleBlockPage);
 });

--- a/test/e2e/extension.spec.ts
+++ b/test/e2e/extension.spec.ts
@@ -49,7 +49,7 @@ async function mockSpaPage(page: Page, pattern: string): Promise<void> {
 }
 
 async function expectBlockedSameTabNavigation(page: Page, targetUrl: string): Promise<void> {
-  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?url=`);
+  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?blockId=`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
 }
@@ -95,9 +95,16 @@ test('redirects matching top-level navigations to the blocked page', async ({
   const targetUrl = 'https://blocked.example.invalid/focus';
   await page.goto(targetUrl).catch(() => undefined);
 
-  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?url=`);
+  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?blockId=`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  const responsibleFilter = page.getByLabel('Responsible filter');
+  await expect(responsibleFilter).toBeVisible();
+  await expect(responsibleFilter).toContainText('E2E Block');
+  await expect(responsibleFilter).toContainText('blocked.example.invalid');
+  await expect(responsibleFilter).toContainText('Contains text');
+  await expect(responsibleFilter).toContainText(defaultGroup.name);
+  await expect(responsibleFilter).toContainText('Always Active');
 });
 
 for (const navigationMethod of ['push-state', 'replace-state'] as const) {

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -46,18 +46,19 @@ export async function readStorage(page: Page): Promise<StorageData | undefined> 
 }
 
 export function getBlockedPagePathFor(targetUrl: string): string {
-  return `/${PAGES.BLOCKED}?url=${encodeURIComponent(targetUrl)}`;
+  void targetUrl;
+  return `/${PAGES.BLOCKED}`;
 }
 
 export async function expectBlocked(
   page: Page,
   targetUrl: string,
-  expectedBlockedUrl = getBlockedPagePathFor(targetUrl)
+  expectedBlockedPath = getBlockedPagePathFor(targetUrl)
 ): Promise<void> {
   await page.goto(targetUrl).catch(() => undefined);
   await expect
     .poll(() => new URL(page.url()).pathname + new URL(page.url()).search)
-    .toBe(expectedBlockedUrl);
+    .toContain(`${expectedBlockedPath}?blockId=`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
 }
@@ -279,16 +280,32 @@ export async function readBlockedTabStateForTarget(
 ): Promise<BlockedTabState | undefined> {
   return page.evaluate(
     async ({ blockedPagePath, url }) => {
-      const blockedUrl = `${chrome.runtime.getURL(blockedPagePath)}?url=${encodeURIComponent(url)}`;
+      const blockedPageUrl = chrome.runtime.getURL(blockedPagePath);
       const tabs = await chrome.tabs.query({});
-      const tab = tabs.find((candidate) => candidate.url === url || candidate.url === blockedUrl);
-      if (typeof tab?.id !== 'number') {
-        return undefined;
+      const directTab = tabs.find((candidate) => candidate.url === url);
+      if (typeof directTab?.id === 'number') {
+        const key = `blocked_tab_state_${directTab.id}`;
+        const result = await chrome.storage.session.get(key);
+        return result[key] as BlockedTabState | undefined;
       }
 
-      const key = `blocked_tab_state_${tab.id}`;
-      const result = await chrome.storage.session.get(key);
-      return result[key] as BlockedTabState | undefined;
+      for (const candidate of tabs) {
+        if (
+          typeof candidate.id !== 'number' ||
+          !candidate.url?.startsWith(`${blockedPageUrl}?blockId=`)
+        ) {
+          continue;
+        }
+
+        const key = `blocked_tab_state_${candidate.id}`;
+        const result = await chrome.storage.session.get(key);
+        const state = result[key] as BlockedTabState | undefined;
+        if (state?.targetUrl === url) {
+          return state;
+        }
+      }
+
+      return undefined;
     },
     { blockedPagePath: PAGES.BLOCKED, url: targetUrl }
   );

--- a/test/e2e/lifecycle.spec.ts
+++ b/test/e2e/lifecycle.spec.ts
@@ -487,7 +487,7 @@ test('editing a schedule through options changes navigation from off-schedule al
 
   await expect
     .poll(() => new URL(browsingPage.url()).pathname + new URL(browsingPage.url()).search)
-    .toBe(`/${PAGES.BLOCKED}?url=${encodeURIComponent(targetUrl)}`);
+    .toContain(`/${PAGES.BLOCKED}?blockId=`);
   await expect(browsingPage.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await captureScreenshot(browsingPage, testInfo, 'schedule-lifecycle-blocked.png');
 });

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   getUrlDecision: vi.fn(),
   getFreshBlockedPageState: vi.fn(),
+  getBlockedPageStateByBlockId: vi.fn(),
   goBackFromActiveTab: vi.fn(),
   loadData: vi.fn(),
 }));
@@ -11,10 +12,12 @@ vi.mock('../../../src/background/tabController', () => ({
   getTabController: (): {
     getUrlDecision: typeof mocks.getUrlDecision;
     getFreshBlockedPageState: typeof mocks.getFreshBlockedPageState;
+    getBlockedPageStateByBlockId: typeof mocks.getBlockedPageStateByBlockId;
     goBackFromActiveTab: typeof mocks.goBackFromActiveTab;
   } => ({
     getUrlDecision: mocks.getUrlDecision,
     getFreshBlockedPageState: mocks.getFreshBlockedPageState,
+    getBlockedPageStateByBlockId: mocks.getBlockedPageStateByBlockId,
     goBackFromActiveTab: mocks.goBackFromActiveTab,
   }),
 }));
@@ -40,6 +43,7 @@ describe('handleMessage', () => {
     mocks.loadData.mockResolvedValue(defaultData);
     mocks.getUrlDecision.mockResolvedValue({ action: 'allow', reason: 'no-match' });
     mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'unavailable' });
+    mocks.getBlockedPageStateByBlockId.mockResolvedValue({ status: 'unavailable' });
     mocks.goBackFromActiveTab.mockResolvedValue(false);
   });
 
@@ -155,6 +159,27 @@ describe('handleMessage', () => {
       expect(sendResponse).toHaveBeenCalledWith({ status: 'unavailable' });
     });
     expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+    expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith(undefined);
+  });
+
+  it('resolves blocked-page state by block id when the sender tab is unavailable', async () => {
+    const blockId = 'block-1';
+    const response = { status: 'allowed', targetUrl: 'https://allowed.com/focus' };
+    mocks.getBlockedPageStateByBlockId.mockResolvedValue(response);
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE, blockId },
+        { id: 'test-extension-id' },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(response);
+    });
+    expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith(blockId);
   });
 
   it('forwards allowed blocked-page state responses', async () => {

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -182,6 +182,28 @@ describe('handleMessage', () => {
     expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith(blockId);
   });
 
+  it('accepts extension page senders when chrome omits the sender id', async () => {
+    const blockId = 'block-from-extension-page';
+    const response = { status: 'allowed', targetUrl: 'https://allowed.com/focus' };
+    mocks.getBlockedPageStateByBlockId.mockResolvedValue(response);
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE, blockId },
+        {
+          url: 'chrome-extension://test-extension-id/src/blocked/index.html?blockId=block-from-extension-page',
+        },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(response);
+    });
+    expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith(blockId);
+  });
+
   it('forwards allowed blocked-page state responses', async () => {
     const response = { status: 'allowed', targetUrl: 'https://allowed.com/focus' };
     mocks.getFreshBlockedPageState.mockResolvedValue(response);

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -3,10 +3,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getBlockedTabState,
   getLastAllowedUrl,
+  setBlockedPageState,
   setBlockedTabState,
 } from '../../../src/shared/api/session';
 import { getChromeMock } from '../../fixtures/chrome-mocks';
-import { DEFAULT_GROUP_ID, STORAGE_KEY, type StorageData } from '../../../src/shared/types';
+import {
+  DEFAULT_GROUP_ID,
+  STORAGE_KEY,
+  type BlockedPageState,
+  type StorageData,
+} from '../../../src/shared/types';
 import { PAGES } from '../../../src/shared/constants';
 
 function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
@@ -18,6 +24,31 @@ function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
     rulesVersion: overrides.rulesVersion ?? 1,
+  };
+}
+
+function createBlockedPageState(overrides: Partial<BlockedPageState>): BlockedPageState {
+  return {
+    blockId: overrides.blockId ?? 'block-1',
+    tabId: overrides.tabId ?? 1,
+    targetUrl: overrides.targetUrl ?? 'https://blocked.com/focus',
+    blockedAt: overrides.blockedAt ?? Date.now(),
+    rulesVersion: overrides.rulesVersion ?? 1,
+    blockedBy: overrides.blockedBy ?? {
+      filterId: 'filter-1',
+      groupId: DEFAULT_GROUP_ID,
+    },
+    filter: overrides.filter ?? {
+      id: 'filter-1',
+      pattern: 'blocked.com',
+      matchMode: 'contains',
+    },
+    group: overrides.group ?? {
+      id: DEFAULT_GROUP_ID,
+      name: '24/7',
+      schedules: [],
+      is24x7: true,
+    },
   };
 }
 
@@ -51,11 +82,14 @@ describe('TabController', () => {
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       4,
       {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
+        url: expect.stringContaining(
+          `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=`
+        ),
       },
       expect.any(Function)
     );
     await expect(getBlockedTabState(4)).resolves.toEqual({
+      blockId: expect.any(String),
       tabId: 4,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: expect.any(Number),
@@ -99,11 +133,14 @@ describe('TabController', () => {
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       6,
       {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
+        url: expect.stringContaining(
+          `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=`
+        ),
       },
       expect.any(Function)
     );
     await expect(getBlockedTabState(6)).resolves.toEqual({
+      blockId: expect.any(String),
       tabId: 6,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: expect.any(Number),
@@ -126,6 +163,7 @@ describe('TabController', () => {
     const chromeMock = getChromeMock();
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'restore-block',
       tabId: 5,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: Date.now(),
@@ -135,11 +173,18 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
+    await setBlockedPageState(
+      createBlockedPageState({
+        blockId: 'restore-block',
+        tabId: 5,
+        targetUrl: 'https://blocked.com/focus',
+      })
+    );
 
     await expect(
       getTabController().restoreIfAllowed(
         5,
-        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`
+        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=restore-block`
       )
     ).resolves.toBe(true);
 
@@ -172,6 +217,7 @@ describe('TabController', () => {
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'stale-block',
       tabId: 7,
       targetUrl: 'https://stale-blocked.com/focus',
       blockedAt: Date.now(),
@@ -181,10 +227,17 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
+    await setBlockedPageState(
+      createBlockedPageState({
+        blockId: 'stale-block',
+        tabId: 7,
+        targetUrl: 'https://allowed.com/focus',
+      })
+    );
 
     await getTabController().evaluateNavigation(
       7,
-      `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://allowed.com/focus')}`
+      `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=stale-block`
     );
 
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
@@ -216,6 +269,7 @@ describe('TabController', () => {
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'fresh-block',
       tabId: 10,
       targetUrl: 'https://stale-blocked.com/focus',
       blockedAt: Date.now(),
@@ -225,13 +279,21 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
+    await setBlockedPageState(
+      createBlockedPageState({
+        blockId: 'fresh-block',
+        tabId: 10,
+        targetUrl: 'https://fresh-blocked.com/focus',
+      })
+    );
 
     await expect(
       getTabController().getFreshBlockedTabState(
         10,
-        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://fresh-blocked.com/focus')}`
+        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=fresh-block`
       )
     ).resolves.toEqual({
+      blockId: expect.any(String),
       tabId: 10,
       targetUrl: 'https://fresh-blocked.com/focus',
       blockedAt: expect.any(Number),
@@ -239,6 +301,72 @@ describe('TabController', () => {
       blockedBy: {
         filterId: 'fresh-filter',
         groupId: DEFAULT_GROUP_ID,
+      },
+    });
+  });
+
+  it('returns blocked-page state by block id without tab sender state', async () => {
+    const chromeMock = getChromeMock();
+    chromeMock.storage.sync._data.set(
+      STORAGE_KEY,
+      createStorageData({
+        filters: [
+          {
+            id: 'matched-tab-filter',
+            pattern: 'matched-tab.com',
+            groupId: DEFAULT_GROUP_ID,
+            enabled: true,
+            matchMode: 'contains',
+          },
+        ],
+        rulesVersion: 11,
+      })
+    );
+    await setBlockedPageState(
+      createBlockedPageState({
+        blockId: 'matched-tab-block',
+        tabId: 14,
+        targetUrl: 'https://matched-tab.com/focus',
+        rulesVersion: 11,
+        blockedBy: {
+          filterId: 'matched-tab-filter',
+          groupId: DEFAULT_GROUP_ID,
+        },
+        filter: {
+          id: 'matched-tab-filter',
+          pattern: 'matched-tab.com',
+          matchMode: 'contains',
+        },
+      })
+    );
+
+    const { getTabController } = await import('../../../src/background/tabController');
+
+    await expect(
+      getTabController().getBlockedPageStateByBlockId('matched-tab-block')
+    ).resolves.toEqual({
+      status: 'blocked',
+      state: {
+        blockId: 'matched-tab-block',
+        tabId: 14,
+        targetUrl: 'https://matched-tab.com/focus',
+        blockedAt: expect.any(Number),
+        rulesVersion: 11,
+        blockedBy: {
+          filterId: 'matched-tab-filter',
+          groupId: DEFAULT_GROUP_ID,
+        },
+        filter: {
+          id: 'matched-tab-filter',
+          pattern: 'matched-tab.com',
+          matchMode: 'contains',
+        },
+        group: {
+          id: DEFAULT_GROUP_ID,
+          name: '24/7',
+          schedules: [],
+          is24x7: true,
+        },
       },
     });
   });
@@ -277,7 +405,9 @@ describe('TabController', () => {
       expect(chromeMock.tabs.update).toHaveBeenCalledWith(
         8,
         {
-          url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
+          url: expect.stringContaining(
+            `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=`
+          ),
         },
         expect.any(Function)
       );
@@ -316,7 +446,9 @@ describe('TabController', () => {
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       12,
       {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com')}`,
+        url: expect.stringContaining(
+          `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=`
+        ),
       },
       expect.any(Function)
     );
@@ -354,7 +486,9 @@ describe('TabController', () => {
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       13,
       {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com')}`,
+        url: expect.stringContaining(
+          `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=`
+        ),
       },
       expect.any(Function)
     );

--- a/test/unit/shared/messages.test.ts
+++ b/test/unit/shared/messages.test.ts
@@ -21,6 +21,18 @@ describe('shared/types/messages', () => {
     expect(isCheckUrlMessage({ type: MessageType.CHECK_URL, url: 42 })).toBe(false);
     expect(isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB })).toBe(true);
     expect(isGetBlockedPageStateMessage({ type: MessageType.GET_BLOCKED_PAGE_STATE })).toBe(true);
+    expect(
+      isGetBlockedPageStateMessage({
+        type: MessageType.GET_BLOCKED_PAGE_STATE,
+        blockId: 'block-1',
+      })
+    ).toBe(true);
+    expect(
+      isGetBlockedPageStateMessage({
+        type: MessageType.GET_BLOCKED_PAGE_STATE,
+        blockId: 42,
+      })
+    ).toBe(false);
   });
 
   it('recognizes broadcast messages', () => {

--- a/test/unit/shared/session.test.ts
+++ b/test/unit/shared/session.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   clearBlockedTabState,
+  getBlockedPageState,
   getBlockedTabState,
   getLastAllowedUrl,
   getSessionSnooze,
+  setBlockedPageState,
   setBlockedTabState,
   setLastAllowedUrl,
   setSessionSnooze,
@@ -25,6 +27,7 @@ describe('shared/api/session', () => {
 
   it('stores, retrieves, and clears blocked tab state by tab id', async () => {
     await setBlockedTabState({
+      blockId: 'block-1',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
@@ -36,6 +39,7 @@ describe('shared/api/session', () => {
     });
 
     await expect(getBlockedTabState(7)).resolves.toEqual({
+      blockId: 'block-1',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
@@ -48,6 +52,71 @@ describe('shared/api/session', () => {
 
     await clearBlockedTabState(7);
     await expect(getBlockedTabState(7)).resolves.toBeUndefined();
+  });
+
+  it('stores, retrieves, and clears blocked page state by block id', async () => {
+    await setBlockedTabState({
+      blockId: 'block-2',
+      tabId: 8,
+      targetUrl: 'https://blocked.com/focus',
+      blockedAt: 1234,
+      rulesVersion: 5,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: 'group-1',
+      },
+    });
+    await setBlockedPageState({
+      blockId: 'block-2',
+      tabId: 8,
+      targetUrl: 'https://blocked.com/focus',
+      blockedAt: 1234,
+      rulesVersion: 5,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: 'group-1',
+      },
+      filter: {
+        id: 'filter-1',
+        pattern: 'blocked.com',
+        matchMode: 'contains',
+        description: 'Blocked Site',
+      },
+      group: {
+        id: 'group-1',
+        name: 'Focus',
+        is24x7: true,
+        schedules: [],
+      },
+    });
+
+    await expect(getBlockedPageState('block-2')).resolves.toEqual({
+      blockId: 'block-2',
+      tabId: 8,
+      targetUrl: 'https://blocked.com/focus',
+      blockedAt: 1234,
+      rulesVersion: 5,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: 'group-1',
+      },
+      filter: {
+        id: 'filter-1',
+        pattern: 'blocked.com',
+        matchMode: 'contains',
+        description: 'Blocked Site',
+      },
+      group: {
+        id: 'group-1',
+        name: 'Focus',
+        is24x7: true,
+        schedules: [],
+      },
+    });
+
+    await clearBlockedTabState(8);
+    await expect(getBlockedTabState(8)).resolves.toBeUndefined();
+    await expect(getBlockedPageState('block-2')).resolves.toBeUndefined();
   });
 
   it('normalizes active session snooze values', async () => {


### PR DESCRIPTION
## Summary

Show the filter responsible for a blocked navigation directly on the blocked page. The page now resolves the stored blocked filter and group IDs against extension data and renders a compact details panel with the filter name, pattern, match mode, group, and schedule.

## Impact

Users can tell which rule blocked the page before jumping into Manage Filters, which makes editing or disabling the right rule easier.

## Validation

- `npm run typecheck`
- `npm run typecheck:test`
- `npm run lint`
- `npm run test:e2e -- extension.spec.ts`