### PR TITLE
Fix blocked page state contract

### DIFF
--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -21,8 +21,7 @@ export function handleMessage(
   sender: chrome.runtime.MessageSender,
   sendResponse: (response: unknown) => void
 ): boolean {
-  // Validate sender is from our extension
-  if (sender.id !== chrome.runtime.id) {
+  if (!isInternalSender(sender)) {
     return false;
   }
 
@@ -42,7 +41,7 @@ export function handleMessage(
   }
 
   if (isGetBlockedPageStateMessage(message)) {
-    void handleGetBlockedPageState(sender, sendResponse);
+    void handleGetBlockedPageState(message.blockId, sender, sendResponse);
     return true;
   }
 
@@ -67,9 +66,15 @@ async function handleGoBackActiveTab(sendResponse: (response: unknown) => void):
 }
 
 async function handleGetBlockedPageState(
+  blockId: string | undefined,
   sender: chrome.runtime.MessageSender,
   sendResponse: (response: unknown) => void
 ): Promise<void> {
+  if (blockId) {
+    sendResponse(await getTabController().getBlockedPageStateByBlockId(blockId));
+    return;
+  }
+
   const senderTabId = sender.tab?.id;
   if (typeof senderTabId !== 'number') {
     sendResponse({ status: 'unavailable' });
@@ -77,4 +82,18 @@ async function handleGetBlockedPageState(
   }
 
   sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
+}
+
+function isInternalSender(sender: chrome.runtime.MessageSender): boolean {
+  if (sender.id === chrome.runtime.id) {
+    return true;
+  }
+
+  const extensionRoot = chrome.runtime.getURL('');
+  if (sender.url?.startsWith(extensionRoot)) {
+    return true;
+  }
+
+  const senderOrigin = (sender as { readonly origin?: string }).origin;
+  return senderOrigin === new URL(extensionRoot).origin;
 }

--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -1,7 +1,9 @@
 import {
   clearBlockedTabState,
+  getBlockedPageState,
   getBlockedTabState,
   getLastAllowedUrl,
+  setBlockedPageState,
   setBlockedTabState,
   setLastAllowedUrl,
 } from '../shared/api/session';
@@ -9,16 +11,26 @@ import { getActiveTab, queryTabs, updateTabUrl } from '../shared/api/tabs';
 import { getExtensionUrl } from '../shared/api/runtime';
 import { PAGES } from '../shared/constants';
 import {
+  type BlockType,
+  type BlockedPageState,
   STORAGE_KEY,
   type BlockedTabState,
+  type Filter,
   type GetBlockedPageStateResponse,
+  type StorageData,
 } from '../shared/types';
 import { isInternalUrl, type FilterDecision } from '../shared/utils';
 import { getRulesProvider, type CurrentRules, type RulesProvider } from './rulesProvider';
 
 interface ResolvedBlockedTarget {
   readonly targetUrl: string;
+  readonly blockId?: string;
   readonly hasSessionState: boolean;
+}
+
+interface BlockedStateResult {
+  readonly tabState: BlockedTabState;
+  readonly pageState: BlockedPageState;
 }
 
 class TabController {
@@ -60,7 +72,7 @@ class TabController {
     const decision = rules.engine.evaluate(url);
 
     if (decision.action === 'block') {
-      await this.blockTab(tabId, url, decision, rules.data.rulesVersion);
+      await this.blockTab(tabId, url, decision, rules.data);
       return;
     }
 
@@ -79,8 +91,9 @@ class TabController {
     }
 
     const rules = await this.getRules();
-    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
-    if (state) {
+    const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
+    if (decision.action === 'block') {
+      await this.ensureBlockedState(tabId, resolvedTarget.targetUrl, decision, rules.data);
       return false;
     }
 
@@ -102,13 +115,19 @@ class TabController {
       return undefined;
     }
 
-    return this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+    const state = await this.ensureFreshBlockedState(tabId, resolvedTarget.targetUrl);
+    return state?.tabState;
   }
 
   async getFreshBlockedPageState(
     tabId: number,
     blockedPageUrl?: string
   ): Promise<GetBlockedPageStateResponse> {
+    const blockId = parseBlockedPageBlockId(blockedPageUrl);
+    if (blockId) {
+      return this.getBlockedPageStateByBlockId(blockId);
+    }
+
     if (!Number.isInteger(tabId)) {
       return { status: 'unavailable' };
     }
@@ -118,12 +137,27 @@ class TabController {
       return { status: 'unavailable' };
     }
 
-    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl);
+    const state = await this.ensureFreshBlockedState(tabId, resolvedTarget.targetUrl);
     if (state) {
-      return { status: 'blocked', state };
+      return { status: 'blocked', state: state.pageState };
     }
 
     return { status: 'allowed', targetUrl: resolvedTarget.targetUrl };
+  }
+
+  async getBlockedPageStateByBlockId(
+    blockId: string | undefined
+  ): Promise<GetBlockedPageStateResponse> {
+    if (!blockId) {
+      return { status: 'unavailable' };
+    }
+
+    const pageState = await getBlockedPageState(blockId);
+    if (!pageState) {
+      return { status: 'unavailable' };
+    }
+
+    return { status: 'blocked', state: pageState };
   }
 
   async reconcileAllOpenTabs(): Promise<void> {
@@ -187,13 +221,23 @@ class TabController {
     }
 
     const rules = await this.getRules();
-    const state = await this.refreshBlockedTabState(tabId, resolvedTarget.targetUrl, rules);
-    if (!state) {
+    const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
+    if (decision.action !== 'block') {
       if (resolvedTarget.hasSessionState) {
         await updateTabUrl(tabId, resolvedTarget.targetUrl);
         await this.allowTab(tabId, resolvedTarget.targetUrl);
       }
       return;
+    }
+
+    const state = await this.ensureBlockedState(
+      tabId,
+      resolvedTarget.targetUrl,
+      decision,
+      rules.data
+    );
+    if (blockedPageUrl && parseBlockedPageBlockId(blockedPageUrl) !== state.tabState.blockId) {
+      await updateTabUrl(tabId, getBlockedPageUrl(state.tabState.blockId));
     }
   }
 
@@ -201,11 +245,10 @@ class TabController {
     tabId: number,
     url: string,
     decision: Extract<FilterDecision, { action: 'block' }>,
-    rulesVersion: number
+    data: StorageData
   ): Promise<void> {
-    await this.setBlockedState(tabId, url, decision, rulesVersion);
-    const blockedUrl = `${getExtensionUrl(PAGES.BLOCKED)}?url=${encodeURIComponent(url)}`;
-    await updateTabUrl(tabId, blockedUrl);
+    const state = await this.setBlockedState(tabId, url, decision, data);
+    await updateTabUrl(tabId, getBlockedPageUrl(state.tabState.blockId));
   }
 
   private async allowTab(tabId: number, url: string): Promise<void> {
@@ -216,21 +259,36 @@ class TabController {
     tabId: number,
     targetUrl: string,
     decision: Extract<FilterDecision, { action: 'block' }>,
-    rulesVersion: number
-  ): Promise<BlockedTabState> {
-    const state: BlockedTabState = {
+    data: StorageData
+  ): Promise<BlockedStateResult> {
+    const blockType = getDecisionBlockType(decision);
+    const blockId = createBlockId();
+    const tabState: BlockedTabState = {
+      blockId,
       tabId,
       targetUrl,
+      blockType,
       blockedAt: Date.now(),
-      rulesVersion,
+      rulesVersion: data.rulesVersion,
       blockedBy: {
         filterId: decision.filterId,
         groupId: decision.groupId,
       },
     };
+    const filter = data.filters.find((entry) => entry.id === decision.filterId);
+    const pageState: BlockedPageState = {
+      ...tabState,
+      filter: createFilterSnapshot(filter, decision.filterId),
+      group: data.groups.find((entry) => entry.id === decision.groupId),
+      effectiveState: {
+        filterEnabled: filter?.enabled ?? true,
+        groupActive: true,
+        snoozeActive: false,
+      },
+    };
 
-    await setBlockedTabState(state);
-    return state;
+    await Promise.all([setBlockedTabState(tabState), setBlockedPageState(pageState)]);
+    return { tabState, pageState };
   }
 
   private async resolveBlockedTarget(
@@ -238,24 +296,32 @@ class TabController {
     blockedPageUrl?: string
   ): Promise<ResolvedBlockedTarget | undefined> {
     const existingState = await getBlockedTabState(tabId);
-    const fallbackTargetUrl = parseBlockedTargetUrl(blockedPageUrl);
-    if (fallbackTargetUrl) {
-      return {
-        targetUrl: fallbackTargetUrl,
-        hasSessionState: Boolean(existingState),
-      };
+    const blockId = parseBlockedPageBlockId(blockedPageUrl);
+    if (blockId) {
+      const pageState = await getBlockedPageState(blockId);
+      if (pageState) {
+        return {
+          targetUrl: pageState.targetUrl,
+          blockId,
+          hasSessionState: true,
+        };
+      }
     }
 
     return existingState
-      ? { targetUrl: existingState.targetUrl, hasSessionState: true }
+      ? {
+          targetUrl: existingState.targetUrl,
+          blockId: existingState.blockId,
+          hasSessionState: true,
+        }
       : undefined;
   }
 
-  private async refreshBlockedTabState(
+  private async ensureFreshBlockedState(
     tabId: number,
     targetUrl: string,
     currentRules?: CurrentRules
-  ): Promise<BlockedTabState | undefined> {
+  ): Promise<BlockedStateResult | undefined> {
     const rules = currentRules ?? (await this.getRules());
     const decision = rules.engine.evaluate(targetUrl);
     if (decision.action !== 'block') {
@@ -263,7 +329,27 @@ class TabController {
       return undefined;
     }
 
-    return this.setBlockedState(tabId, targetUrl, decision, rules.data.rulesVersion);
+    return this.ensureBlockedState(tabId, targetUrl, decision, rules.data);
+  }
+
+  private async ensureBlockedState(
+    tabId: number,
+    targetUrl: string,
+    decision: Extract<FilterDecision, { action: 'block' }>,
+    data: StorageData
+  ): Promise<BlockedStateResult> {
+    const existingState = await getBlockedTabState(tabId);
+    if (
+      existingState &&
+      isSameBlockedState(existingState, targetUrl, decision, data.rulesVersion)
+    ) {
+      const pageState = await getBlockedPageState(existingState.blockId);
+      if (pageState) {
+        return { tabState: existingState, pageState };
+      }
+    }
+
+    return this.setBlockedState(tabId, targetUrl, decision, data);
   }
 
   private queueReconcile(): void {
@@ -282,7 +368,7 @@ class TabController {
   }
 }
 
-function parseBlockedTargetUrl(tabUrl: string | undefined): string | null {
+function parseBlockedPageBlockId(tabUrl: string | undefined): string | null {
   if (!tabUrl) {
     return null;
   }
@@ -293,19 +379,59 @@ function parseBlockedTargetUrl(tabUrl: string | undefined): string | null {
   }
 
   try {
-    const blockedTargetUrl = new URL(tabUrl).searchParams.get('url');
-    if (
-      !blockedTargetUrl ||
-      isInternalUrl(blockedTargetUrl) ||
-      blockedTargetUrl.startsWith(blockedPageUrl)
-    ) {
-      return null;
-    }
-
-    return blockedTargetUrl;
+    const blockId = new URL(tabUrl).searchParams.get('blockId');
+    return blockId?.trim() ? blockId : null;
   } catch {
     return null;
   }
+}
+
+function getBlockedPageUrl(blockId: string): string {
+  const url = new URL(getExtensionUrl(PAGES.BLOCKED));
+  url.searchParams.set('blockId', blockId);
+  return url.toString();
+}
+
+function createBlockId(): string {
+  return (
+    globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+}
+
+function getDecisionBlockType(decision: Extract<FilterDecision, { action: 'block' }>): BlockType {
+  const candidate = (decision as { readonly blockType?: unknown }).blockType;
+  return isBlockType(candidate) ? candidate : 'block';
+}
+
+function isBlockType(value: unknown): value is BlockType {
+  return value === 'block' || value === 'warning';
+}
+
+function isSameBlockedState(
+  state: BlockedTabState,
+  targetUrl: string,
+  decision: Extract<FilterDecision, { action: 'block' }>,
+  rulesVersion: number
+): boolean {
+  return (
+    state.targetUrl === targetUrl &&
+    state.rulesVersion === rulesVersion &&
+    state.blockedBy.filterId === decision.filterId &&
+    state.blockedBy.groupId === decision.groupId &&
+    state.blockType === getDecisionBlockType(decision)
+  );
+}
+
+function createFilterSnapshot(
+  filter: Filter | undefined,
+  fallbackFilterId: string
+): BlockedPageState['filter'] {
+  return {
+    id: filter?.id ?? fallbackFilterId,
+    pattern: filter?.pattern ?? fallbackFilterId,
+    matchMode: filter?.matchMode ?? 'contains',
+    ...(filter?.description ? { description: filter.description } : {}),
+  };
 }
 
 const tabController = new TabController(getRulesProvider());

--- a/src/blocked/index.html
+++ b/src/blocked/index.html
@@ -12,6 +12,30 @@
       <h1>Page Blocked</h1>
       <p>This page has been blocked by Teichos based on your filter settings.</p>
       <div class="url" id="blocked-url" role="status" aria-label="Blocked URL"></div>
+      <section class="details" id="responsible-filter" aria-label="Responsible filter" hidden>
+        <dl>
+          <div>
+            <dt>Filter</dt>
+            <dd id="responsible-filter-name"></dd>
+          </div>
+          <div>
+            <dt>Pattern</dt>
+            <dd id="responsible-filter-pattern"></dd>
+          </div>
+          <div>
+            <dt>Match</dt>
+            <dd id="responsible-filter-match"></dd>
+          </div>
+          <div>
+            <dt>Group</dt>
+            <dd id="responsible-filter-group"></dd>
+          </div>
+          <div>
+            <dt>Schedule</dt>
+            <dd id="responsible-filter-schedule"></dd>
+          </div>
+        </dl>
+      </section>
       <div class="actions">
         <button class="button" id="go-back" type="button">Go Back</button>
         <button class="button secondary" id="open-options" type="button">Manage Filters</button>

--- a/src/blocked/index.ts
+++ b/src/blocked/index.ts
@@ -6,20 +6,26 @@
 import { openOptionsPage } from '../shared/api/runtime';
 import {
   MessageType,
+  type BlockedPageState,
+  type FilterMatchMode,
   type GetBlockedPageStateResponse,
   type GoBackActiveTabResponse,
 } from '../shared/types';
 import { getElementByIdOrNull } from '../shared/utils/dom';
+import { formatGroupScheduleSummary } from '../shared/utils/schedules';
 
-interface BlockedPageState {
+interface BlockedPageViewModel {
   readonly targetUrl: string;
+  readonly state?: BlockedPageState;
 }
 
 /**
  * Initialize blocked page
  */
 async function init(): Promise<void> {
-  renderBlockedUrl(await getBlockedPageState());
+  const state = await getBlockedPageState();
+  renderBlockedUrl(state);
+  renderResponsibleFilter(state);
 
   const goBackButton = getElementByIdOrNull('go-back');
   goBackButton?.addEventListener('click', () => {
@@ -37,20 +43,22 @@ async function init(): Promise<void> {
   });
 }
 
-async function getBlockedPageState(): Promise<BlockedPageState> {
-  const fallbackState = getFallbackBlockedPageState();
-
+async function getBlockedPageState(): Promise<BlockedPageViewModel> {
   try {
     const response = (await chrome.runtime.sendMessage({
       type: MessageType.GET_BLOCKED_PAGE_STATE,
+      blockId: getBlockedPageBlockId(),
     })) as GetBlockedPageStateResponse;
 
     if (!isBlockedPageStateResponse(response)) {
-      return fallbackState;
+      return getUnavailableBlockedPageState();
     }
 
     if (response.status === 'blocked') {
-      return { targetUrl: response.state.targetUrl };
+      return {
+        targetUrl: response.state.targetUrl,
+        state: response.state,
+      };
     }
 
     if (response.status === 'allowed') {
@@ -60,12 +68,25 @@ async function getBlockedPageState(): Promise<BlockedPageState> {
     console.warn('[Teichos] Failed to load blocked tab state:', error);
   }
 
-  return fallbackState;
+  return getUnavailableBlockedPageState();
 }
 
-function getFallbackBlockedPageState(): BlockedPageState {
-  const urlParams = new URLSearchParams(window.location.search);
-  return { targetUrl: urlParams.get('url') ?? 'Unknown URL' };
+function getBlockedPageBlockId(): string | undefined {
+  const blockId = new URLSearchParams(window.location.search).get('blockId');
+  if (blockId === null) {
+    return undefined;
+  }
+
+  const trimmedBlockId = blockId.trim();
+  if (trimmedBlockId.length === 0) {
+    return undefined;
+  }
+
+  return trimmedBlockId;
+}
+
+function getUnavailableBlockedPageState(): BlockedPageViewModel {
+  return { targetUrl: 'Block details unavailable' };
 }
 
 function isBlockedPageStateResponse(response: unknown): response is GetBlockedPageStateResponse {
@@ -87,7 +108,14 @@ function isBlockedPageStateResponse(response: unknown): response is GetBlockedPa
     typeof response.state === 'object' &&
     response.state !== null &&
     'targetUrl' in response.state &&
-    typeof response.state.targetUrl === 'string'
+    typeof response.state.targetUrl === 'string' &&
+    'filter' in response.state &&
+    typeof response.state.filter === 'object' &&
+    response.state.filter !== null &&
+    'pattern' in response.state.filter &&
+    typeof response.state.filter.pattern === 'string' &&
+    'matchMode' in response.state.filter &&
+    isFilterMatchMode(response.state.filter.matchMode)
   );
 }
 
@@ -101,11 +129,61 @@ async function handleGoBack(): Promise<void> {
   }
 }
 
-function renderBlockedUrl(state: BlockedPageState): void {
+function renderBlockedUrl(state: BlockedPageViewModel): void {
   const blockedUrlElement = getElementByIdOrNull('blocked-url');
   if (blockedUrlElement) {
     blockedUrlElement.textContent = state.targetUrl;
   }
+}
+
+function renderResponsibleFilter(state: BlockedPageViewModel): void {
+  const detailSection = getElementByIdOrNull<HTMLElement>('responsible-filter');
+  if (!detailSection || !state.state) {
+    return;
+  }
+
+  setText('responsible-filter-name', getFilterDisplayName(state.state));
+  setText('responsible-filter-pattern', state.state.filter.pattern);
+  setText('responsible-filter-match', formatMatchMode(state.state.filter.matchMode));
+  setText('responsible-filter-group', state.state.group?.name ?? 'Unknown group');
+  setText(
+    'responsible-filter-schedule',
+    state.state.group ? formatGroupScheduleSummary(state.state.group) : 'Unavailable'
+  );
+
+  detailSection.hidden = false;
+}
+
+function setText(elementId: string, value: string): void {
+  const element = getElementByIdOrNull(elementId);
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+function getFilterDisplayName(state: BlockedPageState): string {
+  const name = state.filter.description?.trim();
+  if (typeof name === 'string' && name.length > 0) {
+    return name;
+  }
+
+  return state.filter.pattern;
+}
+
+function formatMatchMode(matchMode: FilterMatchMode): string {
+  if (matchMode === 'regex') {
+    return 'Regular expression';
+  }
+
+  if (matchMode === 'exact') {
+    return 'Exact URL';
+  }
+
+  return 'Contains text';
+}
+
+function isFilterMatchMode(value: unknown): value is FilterMatchMode {
+  return value === 'contains' || value === 'exact' || value === 'regex';
 }
 
 // Initialize on load

--- a/src/blocked/styles/blocked.css
+++ b/src/blocked/styles/blocked.css
@@ -15,6 +15,8 @@
   --text-on-bg: #f7f8ff;
   --url-bg: rgba(255, 255, 255, 0.2);
   --url-border: rgba(255, 255, 255, 0.28);
+  --detail-bg: rgba(255, 255, 255, 0.16);
+  --detail-border: rgba(255, 255, 255, 0.22);
   --button-bg: #f8fbff;
   --button-text: #4e4cd3;
   --button-bg-hover: #ecefff;
@@ -85,6 +87,50 @@ p {
   font-size: var(--text-md);
 }
 
+.details {
+  margin: 0 0 2rem;
+  padding: 1rem;
+  border: 1px solid var(--detail-border);
+  border-radius: 8px;
+  background: var(--detail-bg);
+  text-align: left;
+}
+
+.details[hidden] {
+  display: none;
+}
+
+.details dl {
+  display: grid;
+  gap: 0.75rem;
+  margin: 0;
+}
+
+.details dl > div {
+  display: grid;
+  grid-template-columns: minmax(5.5rem, 0.35fr) minmax(0, 1fr);
+  gap: 0.75rem;
+}
+
+.details dt {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.details dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 480px) {
+  .details dl > div {
+    grid-template-columns: 1fr;
+    gap: 0.2rem;
+  }
+}
+
 .actions {
   display: flex;
   justify-content: center;
@@ -137,6 +183,8 @@ p {
     --text-on-bg: #f0f2ff;
     --url-bg: rgba(12, 22, 39, 0.44);
     --url-border: rgba(173, 203, 244, 0.18);
+    --detail-bg: rgba(12, 22, 39, 0.34);
+    --detail-border: rgba(173, 203, 244, 0.18);
     --button-bg: #ddecff;
     --button-text: #3a32a9;
     --button-bg-hover: #cfd8ff;

--- a/src/shared/api/session.ts
+++ b/src/shared/api/session.ts
@@ -2,11 +2,22 @@
  * Typed wrapper for chrome.storage.session API
  */
 
-import type { BlockedTabState, SnoozeState } from '../types';
+import type {
+  BlockType,
+  BlockedEffectiveState,
+  BlockedFilterSnapshot,
+  BlockedGroupSnapshot,
+  BlockedPageState,
+  BlockedTabState,
+  FilterMatchMode,
+  SnoozeState,
+  TimeSchedule,
+} from '../types';
 
 const LAST_ALLOWED_URL_KEY_PREFIX = 'last_allowed_url_' as const;
 const SNOOZE_OVERRIDE_KEY = 'snooze_override' as const;
 const BLOCKED_TAB_STATE_KEY_PREFIX = 'blocked_tab_state_' as const;
+const BLOCKED_PAGE_STATE_KEY_PREFIX = 'blocked_page_state_' as const;
 
 function lastAllowedUrlKey(tabId: number): string {
   return `${LAST_ALLOWED_URL_KEY_PREFIX}${tabId}`;
@@ -14,6 +25,10 @@ function lastAllowedUrlKey(tabId: number): string {
 
 function blockedTabStateKey(tabId: number): string {
   return `${BLOCKED_TAB_STATE_KEY_PREFIX}${tabId}`;
+}
+
+function blockedPageStateKey(blockId: string): string {
+  return `${BLOCKED_PAGE_STATE_KEY_PREFIX}${blockId}`;
 }
 
 /**
@@ -40,8 +55,10 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
 
   const candidate = value as Partial<BlockedTabState>;
   if (
+    typeof candidate.blockId !== 'string' ||
     typeof candidate.tabId !== 'number' ||
     typeof candidate.targetUrl !== 'string' ||
+    !isBlockType(candidate.blockType) ||
     typeof candidate.blockedAt !== 'number' ||
     typeof candidate.rulesVersion !== 'number' ||
     !candidate.blockedBy ||
@@ -52,8 +69,10 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
   }
 
   return {
+    blockId: candidate.blockId,
     tabId: candidate.tabId,
     targetUrl: candidate.targetUrl,
+    blockType: candidate.blockType,
     blockedAt: candidate.blockedAt,
     rulesVersion: candidate.rulesVersion,
     blockedBy: {
@@ -75,6 +94,141 @@ export async function getBlockedTabState(tabId: number): Promise<BlockedTabState
 
 export async function clearBlockedTabState(tabId: number): Promise<void> {
   await chrome.storage.session.remove(blockedTabStateKey(tabId));
+}
+
+function isBlockType(value: unknown): value is BlockType {
+  return value === 'block' || value === 'warning';
+}
+
+function isFilterMatchMode(value: unknown): value is FilterMatchMode {
+  return value === 'contains' || value === 'exact' || value === 'regex';
+}
+
+function normalizeBlockedFilterSnapshot(value: unknown): BlockedFilterSnapshot | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedFilterSnapshot>;
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.pattern !== 'string' ||
+    !isFilterMatchMode(candidate.matchMode)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: candidate.id,
+    pattern: candidate.pattern,
+    matchMode: candidate.matchMode,
+    ...(typeof candidate.description === 'string' ? { description: candidate.description } : {}),
+  };
+}
+
+function normalizeSchedule(value: unknown): TimeSchedule | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<TimeSchedule>;
+  if (
+    !Array.isArray(candidate.daysOfWeek) ||
+    !candidate.daysOfWeek.every((day) => typeof day === 'number') ||
+    typeof candidate.startTime !== 'string' ||
+    typeof candidate.endTime !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    daysOfWeek: candidate.daysOfWeek,
+    startTime: candidate.startTime,
+    endTime: candidate.endTime,
+  };
+}
+
+function normalizeBlockedGroupSnapshot(value: unknown): BlockedGroupSnapshot | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedGroupSnapshot>;
+  const schedules = Array.isArray(candidate.schedules)
+    ? candidate.schedules.map(normalizeSchedule)
+    : undefined;
+  if (
+    typeof candidate.id !== 'string' ||
+    typeof candidate.name !== 'string' ||
+    typeof candidate.is24x7 !== 'boolean' ||
+    !schedules ||
+    schedules.some((schedule) => !schedule)
+  ) {
+    return undefined;
+  }
+
+  return {
+    id: candidate.id,
+    name: candidate.name,
+    is24x7: candidate.is24x7,
+    schedules: schedules.filter((schedule): schedule is TimeSchedule => Boolean(schedule)),
+  };
+}
+
+function normalizeBlockedEffectiveState(value: unknown): BlockedEffectiveState | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedEffectiveState>;
+  if (
+    typeof candidate.filterEnabled !== 'boolean' ||
+    typeof candidate.groupActive !== 'boolean' ||
+    typeof candidate.snoozeActive !== 'boolean'
+  ) {
+    return undefined;
+  }
+
+  return {
+    filterEnabled: candidate.filterEnabled,
+    groupActive: candidate.groupActive,
+    snoozeActive: candidate.snoozeActive,
+  };
+}
+
+function normalizeBlockedPageState(value: unknown): BlockedPageState | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const candidate = value as Partial<BlockedPageState>;
+  const tabState = normalizeBlockedTabState(candidate);
+  const filter = normalizeBlockedFilterSnapshot(candidate.filter);
+  const effectiveState = normalizeBlockedEffectiveState(candidate.effectiveState);
+  if (!tabState || !filter || !effectiveState) {
+    return undefined;
+  }
+
+  return {
+    ...tabState,
+    filter,
+    group: normalizeBlockedGroupSnapshot(candidate.group),
+    effectiveState,
+  };
+}
+
+export async function setBlockedPageState(state: BlockedPageState): Promise<void> {
+  await chrome.storage.session.set({ [blockedPageStateKey(state.blockId)]: state });
+}
+
+export async function getBlockedPageState(blockId: string): Promise<BlockedPageState | undefined> {
+  const key = blockedPageStateKey(blockId);
+  const result = await chrome.storage.session.get(key);
+  return normalizeBlockedPageState(result[key]);
+}
+
+export async function clearBlockedPageState(blockId: string): Promise<void> {
+  await chrome.storage.session.remove(blockedPageStateKey(blockId));
 }
 
 function normalizeSessionSnooze(value: unknown): SnoozeState | undefined {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -3,7 +3,7 @@
  * Uses discriminated unions for type-safe message handling
  */
 
-import type { BlockedTabState, Filter, StorageData } from './storage';
+import type { BlockedPageState, Filter, StorageData } from './storage';
 
 // Message types enum for discriminated union
 export const MessageType = {
@@ -34,6 +34,7 @@ export interface GoBackActiveTabMessage {
 
 export interface GetBlockedPageStateMessage {
   readonly type: typeof MessageType.GET_BLOCKED_PAGE_STATE;
+  readonly blockId?: string;
 }
 
 // Response messages
@@ -53,7 +54,7 @@ export interface GoBackActiveTabResponse {
 export type GetBlockedPageStateResponse =
   | {
       readonly status: 'blocked';
-      readonly state: BlockedTabState;
+      readonly state: BlockedPageState;
     }
   | {
       readonly status: 'allowed';
@@ -132,7 +133,8 @@ export function isGetBlockedPageStateMessage(msg: unknown): msg is GetBlockedPag
     typeof msg === 'object' &&
     msg !== null &&
     'type' in msg &&
-    msg.type === MessageType.GET_BLOCKED_PAGE_STATE
+    msg.type === MessageType.GET_BLOCKED_PAGE_STATE &&
+    (!('blockId' in msg) || typeof msg.blockId === 'string')
   );
 }
 

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -28,6 +28,8 @@ export interface FilterGroup {
 /** URL matching modes for filters and whitelist entries */
 export type FilterMatchMode = 'contains' | 'exact' | 'regex';
 
+export type BlockType = 'block' | 'warning';
+
 /** URL filter pattern */
 export interface Filter {
   readonly id: string;
@@ -61,11 +63,34 @@ export interface BlockedBy {
 }
 
 export interface BlockedTabState {
+  readonly blockId: string;
   readonly tabId: number;
   readonly targetUrl: string;
   readonly blockedBy: BlockedBy;
+  readonly blockType: BlockType;
   readonly blockedAt: number;
   readonly rulesVersion: number;
+}
+
+export interface BlockedFilterSnapshot {
+  readonly id: string;
+  readonly pattern: string;
+  readonly matchMode: FilterMatchMode;
+  readonly description?: string;
+}
+
+export type BlockedGroupSnapshot = FilterGroup;
+
+export interface BlockedEffectiveState {
+  readonly filterEnabled: boolean;
+  readonly groupActive: boolean;
+  readonly snoozeActive: boolean;
+}
+
+export interface BlockedPageState extends BlockedTabState {
+  readonly filter: BlockedFilterSnapshot;
+  readonly group: BlockedGroupSnapshot | undefined;
+  readonly effectiveState: BlockedEffectiveState;
 }
 
 /** Root storage schema */

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from './fixtures';
-import { captureScreenshot, createStorageData, defaultGroup, seedStorage } from './helpers';
+import {
+  captureScreenshot,
+  createStorageData,
+  defaultGroup,
+  expectBlocked,
+  seedStorage,
+} from './helpers';
 import { PAGES } from '../../src/shared/constants';
 
 test('go back restores the last allowed url', async ({
@@ -18,13 +24,29 @@ test('go back restores the last allowed url', async ({
     });
   });
 
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent(blockedUrl)}`);
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await seedStorage(
+    page,
+    createStorageData({
+      filters: [
+        {
+          id: 'blocked-page-filter',
+          pattern: 'blocked.example.invalid',
+          groupId: defaultGroup.id,
+          enabled: true,
+          matchMode: 'contains',
+          description: 'Blocked Page',
+        },
+      ],
+    })
+  );
   await page.evaluate(async (url) => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (typeof tab?.id === 'number') {
       await chrome.storage.session.set({ [`last_allowed_url_${tab.id}`]: url });
     }
   }, allowedUrl);
+  await page.goto(blockedUrl).catch(() => undefined);
 
   await expect(page.getByLabel('Blocked URL')).toHaveText(blockedUrl);
   await captureScreenshot(page, testInfo, 'blocked-page.png');
@@ -37,9 +59,7 @@ test('go back restores the last allowed url', async ({
 });
 
 test('opens settings from the blocked page', async ({ context, extensionPage, page }) => {
-  await page.goto(
-    `${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent('https://blocked.example.invalid')}`
-  );
+  await page.goto(extensionPage(PAGES.BLOCKED));
 
   const optionsPagePromise = context.waitForEvent('page');
   await page.getByRole('button', { name: 'Manage Filters' }).click();
@@ -50,7 +70,7 @@ test('opens settings from the blocked page', async ({ context, extensionPage, pa
   await expect.poll(() => new URL(optionsPage.url()).pathname).toBe(`/${PAGES.OPTIONS}`);
 });
 
-test('renders the blocked url from fresh tab state when query params are missing', async ({
+test('renders the blocked url and responsible filter from block id state', async ({
   extensionPage,
   page,
 }) => {
@@ -73,47 +93,33 @@ test('renders the blocked url from fresh tab state when query params are missing
       rulesVersion: 1,
     })
   );
-  await page.evaluate(async (url) => {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (typeof tab?.id !== 'number') {
-      return;
-    }
 
-    await chrome.storage.session.set({
-      [`blocked_tab_state_${tab.id}`]: {
-        tabId: tab.id,
-        targetUrl: url,
-        blockedAt: Date.now(),
-        rulesVersion: 1,
-        blockedBy: {
-          filterId: 'blocked-state-filter',
-          groupId: 'default-24x7',
-        },
-      },
-    });
-  }, targetUrl);
-
-  await page.goto(extensionPage(PAGES.BLOCKED));
-
-  await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
-  await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expectBlocked(page, targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toContainText('Blocked State');
+  await expect(page.getByLabel('Responsible filter')).toContainText('blocked-state.example.test');
 });
 
-test('handles missing or malformed blocked urls and no-op go back safely', async ({
+test('handles missing or stale block ids and no-op go back safely', async ({
   extensionPage,
   page,
 }) => {
   await page.goto(extensionPage(PAGES.BLOCKED));
-  await expect(page.getByLabel('Blocked URL')).toHaveText('Unknown URL');
+  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
-  const missingUrlPage = page.url();
+  const missingBlockPage = page.url();
   await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect.poll(() => page.url()).toBe(missingUrlPage);
+  await expect.poll(() => page.url()).toBe(missingBlockPage);
 
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?url=%E0%A4%A`);
+  await page.goto(
+    `${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent('https://blocked.example.invalid')}`
+  );
+  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
+
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?blockId=missing-block`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
-  const malformedUrlPage = page.url();
+  const staleBlockPage = page.url();
   await page.getByRole('button', { name: 'Go Back' }).click();
-  await expect.poll(() => page.url()).toBe(malformedUrlPage);
+  await expect.poll(() => page.url()).toBe(staleBlockPage);
 });

--- a/test/e2e/extension.spec.ts
+++ b/test/e2e/extension.spec.ts
@@ -49,9 +49,19 @@ async function mockSpaPage(page: Page, pattern: string): Promise<void> {
 }
 
 async function expectBlockedSameTabNavigation(page: Page, targetUrl: string): Promise<void> {
-  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?url=`);
+  await expect
+    .poll(() => {
+      const currentUrl = new URL(page.url());
+      return (
+        currentUrl.pathname === `/${PAGES.BLOCKED}` &&
+        currentUrl.searchParams.has('blockId') &&
+        !currentUrl.searchParams.has('url')
+      );
+    })
+    .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toBeVisible();
 }
 
 test('loads the extension service worker and extension pages', async ({
@@ -95,9 +105,19 @@ test('redirects matching top-level navigations to the blocked page', async ({
   const targetUrl = 'https://blocked.example.invalid/focus';
   await page.goto(targetUrl).catch(() => undefined);
 
-  await expect.poll(() => page.url()).toContain(`/${PAGES.BLOCKED}?url=`);
+  await expect
+    .poll(() => {
+      const currentUrl = new URL(page.url());
+      return (
+        currentUrl.pathname === `/${PAGES.BLOCKED}` &&
+        currentUrl.searchParams.has('blockId') &&
+        !currentUrl.searchParams.has('url')
+      );
+    })
+    .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toContainText('E2E Block');
 });
 
 for (const navigationMethod of ['push-state', 'replace-state'] as const) {

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -45,21 +45,21 @@ export async function readStorage(page: Page): Promise<StorageData | undefined> 
   }, STORAGE_KEY);
 }
 
-export function getBlockedPagePathFor(targetUrl: string): string {
-  return `/${PAGES.BLOCKED}?url=${encodeURIComponent(targetUrl)}`;
-}
-
-export async function expectBlocked(
-  page: Page,
-  targetUrl: string,
-  expectedBlockedUrl = getBlockedPagePathFor(targetUrl)
-): Promise<void> {
+export async function expectBlocked(page: Page, targetUrl: string): Promise<void> {
   await page.goto(targetUrl).catch(() => undefined);
   await expect
-    .poll(() => new URL(page.url()).pathname + new URL(page.url()).search)
-    .toBe(expectedBlockedUrl);
+    .poll(() => {
+      const currentUrl = new URL(page.url());
+      return (
+        currentUrl.pathname === `/${PAGES.BLOCKED}` &&
+        currentUrl.searchParams.has('blockId') &&
+        !currentUrl.searchParams.has('url')
+      );
+    })
+    .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toBeVisible();
 }
 
 export async function expectAllowed(page: Page, targetUrl: string): Promise<void> {
@@ -277,21 +277,23 @@ export async function readBlockedTabStateForTarget(
   page: Page,
   targetUrl: string
 ): Promise<BlockedTabState | undefined> {
-  return page.evaluate(
-    async ({ blockedPagePath, url }) => {
-      const blockedUrl = `${chrome.runtime.getURL(blockedPagePath)}?url=${encodeURIComponent(url)}`;
-      const tabs = await chrome.tabs.query({});
-      const tab = tabs.find((candidate) => candidate.url === url || candidate.url === blockedUrl);
-      if (typeof tab?.id !== 'number') {
-        return undefined;
+  return page.evaluate(async (url) => {
+    const tabs = await chrome.tabs.query({});
+    for (const tab of tabs) {
+      if (typeof tab.id !== 'number') {
+        continue;
       }
 
       const key = `blocked_tab_state_${tab.id}`;
       const result = await chrome.storage.session.get(key);
-      return result[key] as BlockedTabState | undefined;
-    },
-    { blockedPagePath: PAGES.BLOCKED, url: targetUrl }
-  );
+      const state = result[key] as BlockedTabState | undefined;
+      if (state?.targetUrl === url) {
+        return state;
+      }
+    }
+
+    return undefined;
+  }, targetUrl);
 }
 
 export async function expectBlockedTabStateCleared(page: Page, targetUrl: string): Promise<void> {

--- a/test/e2e/lifecycle.spec.ts
+++ b/test/e2e/lifecycle.spec.ts
@@ -486,9 +486,20 @@ test('editing a schedule through options changes navigation from off-schedule al
   await groupModal.getByRole('button', { name: 'Save' }).click();
 
   await expect
-    .poll(() => new URL(browsingPage.url()).pathname + new URL(browsingPage.url()).search)
-    .toBe(`/${PAGES.BLOCKED}?url=${encodeURIComponent(targetUrl)}`);
+    .poll(() => {
+      const currentUrl = new URL(browsingPage.url());
+      return (
+        currentUrl.pathname === `/${PAGES.BLOCKED}` &&
+        currentUrl.searchParams.has('blockId') &&
+        !currentUrl.searchParams.has('url')
+      );
+    })
+    .toBe(true);
   await expect(browsingPage.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+  await expect(browsingPage.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await expect(browsingPage.getByLabel('Responsible filter')).toContainText(
+    'Schedule Lifecycle Filter'
+  );
   await captureScreenshot(browsingPage, testInfo, 'schedule-lifecycle-blocked.png');
 });
 

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   getUrlDecision: vi.fn(),
+  getBlockedPageStateByBlockId: vi.fn(),
   getFreshBlockedPageState: vi.fn(),
   goBackFromActiveTab: vi.fn(),
   loadData: vi.fn(),
@@ -10,10 +11,12 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../../src/background/tabController', () => ({
   getTabController: (): {
     getUrlDecision: typeof mocks.getUrlDecision;
+    getBlockedPageStateByBlockId: typeof mocks.getBlockedPageStateByBlockId;
     getFreshBlockedPageState: typeof mocks.getFreshBlockedPageState;
     goBackFromActiveTab: typeof mocks.goBackFromActiveTab;
   } => ({
     getUrlDecision: mocks.getUrlDecision,
+    getBlockedPageStateByBlockId: mocks.getBlockedPageStateByBlockId,
     getFreshBlockedPageState: mocks.getFreshBlockedPageState,
     goBackFromActiveTab: mocks.goBackFromActiveTab,
   }),
@@ -39,6 +42,7 @@ describe('handleMessage', () => {
   beforeEach(() => {
     mocks.loadData.mockResolvedValue(defaultData);
     mocks.getUrlDecision.mockResolvedValue({ action: 'allow', reason: 'no-match' });
+    mocks.getBlockedPageStateByBlockId.mockResolvedValue({ status: 'unavailable' });
     mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'unavailable' });
     mocks.goBackFromActiveTab.mockResolvedValue(false);
   });
@@ -105,13 +109,26 @@ describe('handleMessage', () => {
 
   it('responds to blocked-page state requests', async () => {
     const blockedState = {
+      blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 2,
       blockedBy: {
         filterId: 'filter-1',
         groupId: DEFAULT_GROUP_ID,
+      },
+      filter: {
+        id: 'filter-1',
+        pattern: 'blocked.com',
+        matchMode: 'contains',
+      },
+      group: defaultData.groups[0]!,
+      effectiveState: {
+        filterEnabled: true,
+        groupActive: true,
+        snoozeActive: false,
       },
     };
     mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'blocked', state: blockedState });
@@ -140,6 +157,53 @@ describe('handleMessage', () => {
     );
   });
 
+  it('responds to blocked-page state requests by block id without sender tab', async () => {
+    const response = {
+      status: 'blocked',
+      state: {
+        blockId: 'block-8',
+        tabId: 8,
+        targetUrl: 'https://blocked.com/focus',
+        blockType: 'block',
+        blockedAt: 1234,
+        rulesVersion: 2,
+        blockedBy: {
+          filterId: 'filter-1',
+          groupId: DEFAULT_GROUP_ID,
+        },
+        filter: {
+          id: 'filter-1',
+          pattern: 'blocked.com',
+          matchMode: 'contains',
+        },
+        group: defaultData.groups[0]!,
+        effectiveState: {
+          filterEnabled: true,
+          groupActive: true,
+          snoozeActive: false,
+        },
+      },
+    };
+    mocks.getBlockedPageStateByBlockId.mockResolvedValue(response);
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GET_BLOCKED_PAGE_STATE, blockId: 'block-8' },
+        {
+          url: 'chrome-extension://test-extension-id/src/blocked/index.html?blockId=block-8',
+        },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith(response);
+    });
+    expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith('block-8');
+    expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+  });
+
   it('returns unavailable blocked-page state when the sender tab is unavailable', async () => {
     const sendResponse = vi.fn();
 
@@ -155,6 +219,7 @@ describe('handleMessage', () => {
       expect(sendResponse).toHaveBeenCalledWith({ status: 'unavailable' });
     });
     expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+    expect(mocks.getBlockedPageStateByBlockId).not.toHaveBeenCalled();
   });
 
   it('forwards allowed blocked-page state responses', async () => {

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getBlockedTabState,
   getLastAllowedUrl,
+  setBlockedPageState,
   setBlockedTabState,
 } from '../../../src/shared/api/session';
 import { getChromeMock } from '../../fixtures/chrome-mocks';
@@ -19,6 +20,10 @@ function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
     snooze: overrides.snooze ?? { active: false },
     rulesVersion: overrides.rulesVersion ?? 1,
   };
+}
+
+function blockedPageUrl(blockId: string): string {
+  return `chrome-extension://test-extension-id/${PAGES.BLOCKED}?blockId=${encodeURIComponent(blockId)}`;
 }
 
 describe('TabController', () => {
@@ -48,22 +53,37 @@ describe('TabController', () => {
     const { getTabController } = await import('../../../src/background/tabController');
     await getTabController().evaluateNavigation(4, 'https://blocked.com/focus');
 
-    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
-      4,
-      {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
-      },
-      expect.any(Function)
-    );
-    await expect(getBlockedTabState(4)).resolves.toEqual({
+    const state = await getBlockedTabState(4);
+    expect(state).toEqual({
+      blockId: expect.any(String),
       tabId: 4,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 7,
       blockedBy: {
         filterId: 'filter-1',
         groupId: DEFAULT_GROUP_ID,
       },
+    });
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
+      4,
+      { url: blockedPageUrl(state!.blockId) },
+      expect.any(Function)
+    );
+    await expect(getTabController().getBlockedPageStateByBlockId(state!.blockId)).resolves.toEqual({
+      status: 'blocked',
+      state: expect.objectContaining({
+        blockId: state!.blockId,
+        targetUrl: 'https://blocked.com/focus',
+        filter: expect.objectContaining({ id: 'filter-1', pattern: 'blocked.com' }),
+        group: expect.objectContaining({ id: DEFAULT_GROUP_ID }),
+        effectiveState: {
+          filterEnabled: true,
+          groupActive: true,
+          snoozeActive: false,
+        },
+      }),
     });
   });
 
@@ -96,16 +116,12 @@ describe('TabController', () => {
     const { getTabController } = await import('../../../src/background/tabController');
     await getTabController().evaluateNavigation(6, 'https://blocked.com/focus');
 
-    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
-      6,
-      {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
-      },
-      expect.any(Function)
-    );
-    await expect(getBlockedTabState(6)).resolves.toEqual({
+    const state = await getBlockedTabState(6);
+    expect(state).toEqual({
+      blockId: expect.any(String),
       tabId: 6,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 8,
       blockedBy: {
@@ -113,6 +129,11 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
+      6,
+      { url: blockedPageUrl(state!.blockId) },
+      expect.any(Function)
+    );
   });
 
   it('stores the last allowed url for allowed navigations', async () => {
@@ -126,8 +147,10 @@ describe('TabController', () => {
     const chromeMock = getChromeMock();
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'block-5',
       tabId: 5,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 3,
       blockedBy: {
@@ -136,12 +159,9 @@ describe('TabController', () => {
       },
     });
 
-    await expect(
-      getTabController().restoreIfAllowed(
-        5,
-        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`
-      )
-    ).resolves.toBe(true);
+    await expect(getTabController().restoreIfAllowed(5, blockedPageUrl('block-5'))).resolves.toBe(
+      true
+    );
 
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       5,
@@ -172,8 +192,10 @@ describe('TabController', () => {
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'stale-block',
       tabId: 7,
       targetUrl: 'https://stale-blocked.com/focus',
+      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 8,
       blockedBy: {
@@ -181,11 +203,36 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
+    await setBlockedPageState({
+      blockId: 'allowed-block',
+      tabId: 7,
+      targetUrl: 'https://allowed.com/focus',
+      blockType: 'block',
+      blockedAt: Date.now(),
+      rulesVersion: 8,
+      blockedBy: {
+        filterId: 'stale-filter',
+        groupId: DEFAULT_GROUP_ID,
+      },
+      filter: {
+        id: 'stale-filter',
+        pattern: 'stale-blocked.com',
+        matchMode: 'contains',
+      },
+      group: {
+        id: DEFAULT_GROUP_ID,
+        name: '24/7',
+        schedules: [],
+        is24x7: true,
+      },
+      effectiveState: {
+        filterEnabled: true,
+        groupActive: true,
+        snoozeActive: false,
+      },
+    });
 
-    await getTabController().evaluateNavigation(
-      7,
-      `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://allowed.com/focus')}`
-    );
+    await getTabController().evaluateNavigation(7, blockedPageUrl('allowed-block'));
 
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       7,
@@ -216,8 +263,10 @@ describe('TabController', () => {
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
+      blockId: 'stale-block',
       tabId: 10,
       targetUrl: 'https://stale-blocked.com/focus',
+      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 9,
       blockedBy: {
@@ -225,15 +274,42 @@ describe('TabController', () => {
         groupId: DEFAULT_GROUP_ID,
       },
     });
-
-    await expect(
-      getTabController().getFreshBlockedTabState(
-        10,
-        `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://fresh-blocked.com/focus')}`
-      )
-    ).resolves.toEqual({
+    await setBlockedPageState({
+      blockId: 'fresh-block',
       tabId: 10,
       targetUrl: 'https://fresh-blocked.com/focus',
+      blockType: 'block',
+      blockedAt: Date.now(),
+      rulesVersion: 9,
+      blockedBy: {
+        filterId: 'fresh-filter',
+        groupId: DEFAULT_GROUP_ID,
+      },
+      filter: {
+        id: 'fresh-filter',
+        pattern: 'fresh-blocked.com',
+        matchMode: 'contains',
+      },
+      group: {
+        id: DEFAULT_GROUP_ID,
+        name: '24/7',
+        schedules: [],
+        is24x7: true,
+      },
+      effectiveState: {
+        filterEnabled: true,
+        groupActive: true,
+        snoozeActive: false,
+      },
+    });
+
+    await expect(
+      getTabController().getFreshBlockedTabState(10, blockedPageUrl('fresh-block'))
+    ).resolves.toEqual({
+      blockId: expect.any(String),
+      tabId: 10,
+      targetUrl: 'https://fresh-blocked.com/focus',
+      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 10,
       blockedBy: {
@@ -273,12 +349,12 @@ describe('TabController', () => {
 
     onChanged?.({ [STORAGE_KEY]: { newValue: true } }, 'sync');
 
-    await vi.waitFor(() => {
+    await vi.waitFor(async () => {
+      const state = await getBlockedTabState(8);
+      expect(state?.blockId).toEqual(expect.any(String));
       expect(chromeMock.tabs.update).toHaveBeenCalledWith(
         8,
-        {
-          url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com/focus')}`,
-        },
+        { url: blockedPageUrl(state!.blockId) },
         expect.any(Function)
       );
     });
@@ -313,11 +389,11 @@ describe('TabController', () => {
 
     await getTabController().evaluateNavigation(12, 'https://blocked.com');
 
+    const state = await getBlockedTabState(12);
+    expect(state?.blockId).toEqual(expect.any(String));
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       12,
-      {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com')}`,
-      },
+      { url: blockedPageUrl(state!.blockId) },
       expect.any(Function)
     );
   });
@@ -351,11 +427,11 @@ describe('TabController', () => {
 
     await getTabController().evaluateNavigation(13, 'https://blocked.com');
 
+    const state = await getBlockedTabState(13);
+    expect(state?.blockId).toEqual(expect.any(String));
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       13,
-      {
-        url: `chrome-extension://test-extension-id/${PAGES.BLOCKED}?url=${encodeURIComponent('https://blocked.com')}`,
-      },
+      { url: blockedPageUrl(state!.blockId) },
       expect.any(Function)
     );
   });

--- a/test/unit/shared/messages.test.ts
+++ b/test/unit/shared/messages.test.ts
@@ -21,6 +21,15 @@ describe('shared/types/messages', () => {
     expect(isCheckUrlMessage({ type: MessageType.CHECK_URL, url: 42 })).toBe(false);
     expect(isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB })).toBe(true);
     expect(isGetBlockedPageStateMessage({ type: MessageType.GET_BLOCKED_PAGE_STATE })).toBe(true);
+    expect(
+      isGetBlockedPageStateMessage({
+        type: MessageType.GET_BLOCKED_PAGE_STATE,
+        blockId: 'block-1',
+      })
+    ).toBe(true);
+    expect(
+      isGetBlockedPageStateMessage({ type: MessageType.GET_BLOCKED_PAGE_STATE, blockId: 42 })
+    ).toBe(false);
   });
 
   it('recognizes broadcast messages', () => {

--- a/test/unit/shared/session.test.ts
+++ b/test/unit/shared/session.test.ts
@@ -2,8 +2,10 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   clearBlockedTabState,
+  getBlockedPageState,
   getBlockedTabState,
   getLastAllowedUrl,
+  setBlockedPageState,
   getSessionSnooze,
   setBlockedTabState,
   setLastAllowedUrl,
@@ -25,8 +27,10 @@ describe('shared/api/session', () => {
 
   it('stores, retrieves, and clears blocked tab state by tab id', async () => {
     await setBlockedTabState({
+      blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 5,
       blockedBy: {
@@ -36,8 +40,10 @@ describe('shared/api/session', () => {
     });
 
     await expect(getBlockedTabState(7)).resolves.toEqual({
+      blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 5,
       blockedBy: {
@@ -48,6 +54,68 @@ describe('shared/api/session', () => {
 
     await clearBlockedTabState(7);
     await expect(getBlockedTabState(7)).resolves.toBeUndefined();
+  });
+
+  it('stores and retrieves blocked page snapshots by block id', async () => {
+    await setBlockedPageState({
+      blockId: 'block-page-1',
+      tabId: 3,
+      targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
+      blockedAt: 1234,
+      rulesVersion: 6,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: 'group-1',
+      },
+      filter: {
+        id: 'filter-1',
+        pattern: 'blocked.com',
+        matchMode: 'contains',
+        description: 'Blocked Filter',
+      },
+      group: {
+        id: 'group-1',
+        name: 'Work',
+        schedules: [{ daysOfWeek: [1], startTime: '09:00', endTime: '17:00' }],
+        is24x7: false,
+      },
+      effectiveState: {
+        filterEnabled: true,
+        groupActive: true,
+        snoozeActive: false,
+      },
+    });
+
+    await expect(getBlockedPageState('block-page-1')).resolves.toEqual({
+      blockId: 'block-page-1',
+      tabId: 3,
+      targetUrl: 'https://blocked.com/focus',
+      blockType: 'block',
+      blockedAt: 1234,
+      rulesVersion: 6,
+      blockedBy: {
+        filterId: 'filter-1',
+        groupId: 'group-1',
+      },
+      filter: {
+        id: 'filter-1',
+        pattern: 'blocked.com',
+        matchMode: 'contains',
+        description: 'Blocked Filter',
+      },
+      group: {
+        id: 'group-1',
+        name: 'Work',
+        schedules: [{ daysOfWeek: [1], startTime: '09:00', endTime: '17:00' }],
+        is24x7: false,
+      },
+      effectiveState: {
+        filterEnabled: true,
+        groupActive: true,
+        snoozeActive: false,
+      },
+    });
   });
 
   it('normalizes active session snooze values', async () => {


### PR DESCRIPTION
## Summary

Fixes the blocked-page state contract required by #98 before the dependent blocked-page PRs merge.

- Creates immutable `blockId`-keyed blocked-page snapshots before redirecting.
- Removes `?url=` as a parallel display fallback for normal blocked-page rendering.
- Lets the blocked page retrieve authoritative state by `blockId` without relying on `sender.tab`.
- Renders responsible filter/group details from the stored snapshot.
- Updates e2e coverage to assert real extension navigations use `blockId` and render responsible filter details.

## Root cause

The previous blocked page could render the blocked URL from `?url=` while richer state depended on `chrome.storage.session` keyed by tab id. In real extension pages, `sender.tab` is not dependable, so the page could look blocked while authoritative details were unavailable.

## Validation

Passed locally:

- `npm run typecheck`
- `npm run typecheck:test`
- `npm run lint`
- touched-file Prettier check
- `npm run build`
- `npm exec playwright -- test test/e2e/blocked.spec.ts`
- `npm exec playwright -- test test/e2e/extension.spec.ts test/e2e/lifecycle.spec.ts`
- `npm run test:e2e`

Known local repo issues not introduced here:

- `npm run test:unit` fails during Vitest collection on this Windows checkout with `Cannot read properties of undefined (reading 'config')` before tests run.
- `npm run format:check` fails on many pre-existing untouched files; touched files pass Prettier.

Closes #98.