### PR TITLE
Fix F5 debug profile and blocked-page state

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,9 @@
         "--disable-features=DisableLoadExtensionCommandLineSwitch",
         "--enable-unsafe-extension-debugging",
         "--no-first-run",
-        "--no-default-browser-check"
+        "--no-default-browser-check",
+        "--disable-session-crashed-bubble",
+        "--new-window"
       ],
       "webRoot": "${workspaceFolder}/dist",
       "sourceMaps": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,6 +24,12 @@
       "problemMatcher": []
     },
     {
+      "label": "Prepare Chrome Debug Profile",
+      "type": "shell",
+      "command": "$profile = Join-Path (Get-Location) '.vscode\\chrome-debug-profile'; $escapedProfile = [Regex]::Escape($profile); Get-CimInstance Win32_Process -Filter \"name = 'chrome.exe'\" | Where-Object { $_.CommandLine -match $escapedProfile } | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }; Start-Sleep -Milliseconds 500; @('Default\\Sessions', 'Default\\Service Worker', 'Default\\Extension Scripts', 'Default\\Code Cache', 'Default\\Cache', 'Default\\Session Storage') | ForEach-Object { $path = Join-Path $profile $_; if (Test-Path -LiteralPath $path) { Remove-Item -LiteralPath $path -Recurse -Force } }; $prefs = Join-Path $profile 'Default\\Preferences'; if (Test-Path -LiteralPath $prefs) { $json = Get-Content -LiteralPath $prefs -Raw | ConvertFrom-Json; if (-not $json.profile) { $json | Add-Member -MemberType NoteProperty -Name profile -Value ([pscustomobject]@{}) }; $json.profile.exit_type = 'Normal'; if ($null -eq $json.profile.exited_cleanly) { $json.profile | Add-Member -MemberType NoteProperty -Name exited_cleanly -Value $true } else { $json.profile.exited_cleanly = $true }; $json | ConvertTo-Json -Depth 100 -Compress | Set-Content -LiteralPath $prefs -Encoding UTF8 }",
+      "problemMatcher": []
+    },
+    {
       "label": "Install Playwright Chromium",
       "type": "npm",
       "script": "playwright:install",
@@ -32,7 +38,12 @@
     {
       "label": "Build Dev and Ensure Playwright Chromium",
       "dependsOrder": "sequence",
-      "dependsOn": ["Ensure Dependencies", "Build Dev", "Install Playwright Chromium"],
+      "dependsOn": [
+        "Ensure Dependencies",
+        "Prepare Chrome Debug Profile",
+        "Build Dev",
+        "Install Playwright Chromium"
+      ],
       "problemMatcher": []
     },
     {

--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -37,7 +37,7 @@ export function handleMessage(
   }
 
   if (isGoBackActiveTabMessage(message)) {
-    void handleGoBackActiveTab(sender, sendResponse);
+    void handleGoBackActiveTab(message.blockId, sender, sendResponse);
     return true;
   }
 
@@ -68,12 +68,14 @@ async function handleCheckUrl(
 }
 
 async function handleGoBackActiveTab(
+  blockId: string | undefined,
   sender: chrome.runtime.MessageSender,
   sendResponse: (response: unknown) => void
 ): Promise<void> {
   const senderTabId = sender.tab?.id;
-  const restored =
-    typeof senderTabId === 'number'
+  const restored = blockId
+    ? await getTabController().goBackFromBlockedPage(blockId)
+    : typeof senderTabId === 'number'
       ? await getTabController().goBackFromTab(senderTabId)
       : await getTabController().goBackFromActiveTab();
   sendResponse({ restored });
@@ -85,12 +87,11 @@ async function handleContinueActiveTab(
   sendResponse: (response: unknown) => void
 ): Promise<void> {
   const senderTabId = sender.tab?.id;
-  const continued =
-    typeof senderTabId === 'number'
-      ? await getTabController().continueFromTab(senderTabId, sender.tab?.url, blockId)
-      : blockId
-        ? await getTabController().continueFromBlockedPage(blockId)
-        : await getTabController().continueFromActiveTab();
+  const continued = blockId
+    ? await getTabController().continueFromBlockedPage(blockId)
+    : typeof senderTabId === 'number'
+      ? await getTabController().continueFromTab(senderTabId, sender.tab?.url)
+      : await getTabController().continueFromActiveTab();
   sendResponse({ continued });
 }
 
@@ -100,13 +101,13 @@ async function handleGetBlockedPageState(
   sendResponse: (response: unknown) => void
 ): Promise<void> {
   const senderTabId = sender.tab?.id;
-  if (typeof senderTabId === 'number') {
-    sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
+  if (blockId) {
+    sendResponse(await getTabController().getFreshBlockedPageStateByBlockId(blockId));
     return;
   }
 
-  if (blockId) {
-    sendResponse(await getTabController().getBlockedPageStateByBlockId(blockId));
+  if (typeof senderTabId === 'number') {
+    sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
     return;
   }
 

--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -1,4 +1,5 @@
 import {
+  clearBlockedPageState,
   clearBlockedTabState,
   clearWarningBypassState,
   getBlockedPageState,
@@ -29,7 +30,7 @@ interface ResolvedBlockedTarget {
   readonly targetUrl: string;
   readonly blockId?: string;
   readonly tabId?: number;
-  readonly hasSessionState: boolean;
+  readonly shouldRestoreWhenAllowed: boolean;
 }
 
 interface BlockedStateResult {
@@ -114,7 +115,10 @@ class TabController {
     }
 
     await updateTabUrl(tabId, resolvedTarget.targetUrl);
-    await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveWarningBypass: bypassed });
+    await this.allowTab(tabId, resolvedTarget.targetUrl, {
+      blockId: resolvedTarget.blockId,
+      preserveWarningBypass: bypassed,
+    });
     return true;
   }
 
@@ -151,9 +155,16 @@ class TabController {
 
     const state = await this.ensureFreshBlockedState(tabId, resolvedTarget.targetUrl);
     if (state) {
+      if (blockedPageUrl && parseBlockedPageBlockId(blockedPageUrl) !== state.tabState.blockId) {
+        await updateTabUrl(tabId, getBlockedPageUrl(state.tabState.blockId));
+      }
       return { status: 'blocked', state: state.pageState };
     }
 
+    if (resolvedTarget.shouldRestoreWhenAllowed) {
+      await updateTabUrl(tabId, resolvedTarget.targetUrl);
+      await this.allowTab(tabId, resolvedTarget.targetUrl, { blockId: resolvedTarget.blockId });
+    }
     return { status: 'allowed', targetUrl: resolvedTarget.targetUrl };
   }
 
@@ -170,6 +181,21 @@ class TabController {
     }
 
     return { status: 'blocked', state: pageState };
+  }
+
+  async getFreshBlockedPageStateByBlockId(
+    blockId: string | undefined
+  ): Promise<GetBlockedPageStateResponse> {
+    if (!blockId) {
+      return { status: 'unavailable' };
+    }
+
+    const pageState = await getBlockedPageState(blockId);
+    if (!pageState) {
+      return { status: 'unavailable' };
+    }
+
+    return this.getFreshBlockedPageState(pageState.tabId, getBlockedPageUrl(blockId));
   }
 
   async reconcileAllOpenTabs(): Promise<void> {
@@ -200,7 +226,7 @@ class TabController {
     return this.goBackFromTab(activeTab.id);
   }
 
-  async goBackFromTab(tabId: number): Promise<boolean> {
+  async goBackFromTab(tabId: number, blockId?: string): Promise<boolean> {
     const lastAllowedUrl = await getLastAllowedUrl(tabId);
     if (!lastAllowedUrl || isInternalUrl(lastAllowedUrl)) {
       return false;
@@ -212,8 +238,17 @@ class TabController {
     }
 
     await updateTabUrl(tabId, lastAllowedUrl);
-    await this.allowTab(tabId, lastAllowedUrl);
+    await this.allowTab(tabId, lastAllowedUrl, { blockId });
     return true;
+  }
+
+  async goBackFromBlockedPage(blockId: string): Promise<boolean> {
+    const pageState = await getBlockedPageState(blockId);
+    if (!pageState) {
+      return false;
+    }
+
+    return this.goBackFromTab(pageState.tabId, blockId);
   }
 
   async continueFromActiveTab(): Promise<boolean> {
@@ -256,6 +291,7 @@ class TabController {
         filterId: decision.filterId,
         urlKey: getWarningBypassUrlKey(resolvedTarget.targetUrl),
       }),
+      ...(resolvedTarget.blockId ? [clearBlockedPageState(resolvedTarget.blockId)] : []),
       clearBlockedTabState(targetTabId),
       setLastAllowedUrl(targetTabId, resolvedTarget.targetUrl),
     ]);
@@ -290,9 +326,12 @@ class TabController {
       decision.blockType === 'warning' &&
       (await this.isWarningBypassed(tabId, resolvedTarget.targetUrl, decision));
     if (decision.action !== 'block' || bypassed) {
-      if (resolvedTarget.hasSessionState) {
+      if (resolvedTarget.shouldRestoreWhenAllowed) {
         await updateTabUrl(tabId, resolvedTarget.targetUrl);
-        await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveWarningBypass: bypassed });
+        await this.allowTab(tabId, resolvedTarget.targetUrl, {
+          blockId: resolvedTarget.blockId,
+          preserveWarningBypass: bypassed,
+        });
       }
       return;
     }
@@ -321,12 +360,19 @@ class TabController {
   private async allowTab(
     tabId: number,
     url: string,
-    options?: { readonly preserveWarningBypass?: boolean }
+    options?: {
+      readonly blockId?: string | undefined;
+      readonly preserveWarningBypass?: boolean;
+    }
   ): Promise<void> {
     const operations: Promise<void>[] = [
       clearBlockedTabState(tabId),
       setLastAllowedUrl(tabId, url),
     ];
+
+    if (options?.blockId) {
+      operations.push(clearBlockedPageState(options.blockId));
+    }
 
     if (!options?.preserveWarningBypass) {
       const warningBypass = await getWarningBypassState(tabId);
@@ -388,7 +434,7 @@ class TabController {
           targetUrl: pageState.targetUrl,
           blockId,
           tabId: pageState.tabId,
-          hasSessionState: true,
+          shouldRestoreWhenAllowed: true,
         };
       }
     }
@@ -398,7 +444,7 @@ class TabController {
           targetUrl: existingState.targetUrl,
           blockId: existingState.blockId,
           tabId: existingState.tabId,
-          hasSessionState: true,
+          shouldRestoreWhenAllowed: true,
         }
       : undefined;
   }
@@ -408,6 +454,10 @@ class TabController {
     targetUrl: string,
     currentRules?: CurrentRules
   ): Promise<BlockedStateResult | undefined> {
+    if (!currentRules) {
+      this.rulesProvider.invalidate();
+    }
+
     const rules = currentRules ?? (await this.getRules());
     const decision = rules.engine.evaluate(targetUrl);
     if (

--- a/src/blocked/index.ts
+++ b/src/blocked/index.ts
@@ -142,8 +142,10 @@ function isBlockedPageStateResponse(response: unknown): response is GetBlockedPa
 }
 
 async function handleGoBack(): Promise<void> {
+  const blockId = getBlockedPageBlockId();
   const response = await sendExtensionMessage({
     type: MessageType.GO_BACK_ACTIVE_TAB,
+    ...(blockId ? { blockId } : {}),
   });
 
   if (!response.restored) {

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -27,6 +27,7 @@ export interface CheckUrlMessage {
 
 export interface GoBackActiveTabMessage {
   readonly type: typeof MessageType.GO_BACK_ACTIVE_TAB;
+  readonly blockId?: string;
 }
 
 export interface ContinueActiveTabMessage {
@@ -115,7 +116,8 @@ export function isGoBackActiveTabMessage(msg: unknown): msg is GoBackActiveTabMe
     typeof msg === 'object' &&
     msg !== null &&
     'type' in msg &&
-    msg.type === MessageType.GO_BACK_ACTIVE_TAB
+    msg.type === MessageType.GO_BACK_ACTIVE_TAB &&
+    (!('blockId' in msg) || typeof msg.blockId === 'string')
   );
 }
 

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -42,19 +42,14 @@ test('go back restores the last allowed url', async ({
       ],
     })
   );
-  await page.evaluate(async (url) => {
-    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
-    if (typeof tab?.id === 'number') {
-      await chrome.storage.session.set({ [`last_allowed_url_${tab.id}`]: url });
-    }
-  }, allowedUrl);
+  await page.goto(allowedUrl);
+  await expect(page.getByText('Allowed page')).toBeVisible();
+
   await expectBlocked(page, blockedUrl);
   await captureScreenshot(page, testInfo, 'blocked-page.png');
 
-  await Promise.all([
-    page.waitForURL(allowedUrl),
-    page.getByRole('button', { name: 'Go Back' }).click(),
-  ]);
+  await page.getByRole('button', { name: 'Go Back' }).click();
+  await expect.poll(() => page.url()).toBe(allowedUrl);
   await expect(page.getByText('Allowed page')).toBeVisible();
 });
 
@@ -129,6 +124,41 @@ test('warning blocks show Continue and allow same-tab bypass', async ({ extensio
   await expectAllowed(page, targetUrl);
 });
 
+test('restores a canonical blocked page when its group is disabled', async ({
+  extensionPage,
+  page,
+}) => {
+  const targetUrl = 'https://blocked-group-disabled.example.test/search?q=asdf';
+  await mockAllowedPage(page, targetUrl, 'Disabled group target allowed');
+
+  const initialData = createStorageData({
+    filters: [
+      {
+        id: 'group-disabled-filter',
+        pattern: 'asdf',
+        groupId: defaultGroup.id,
+        enabled: true,
+        matchMode: 'contains',
+        description: 'Group Disabled Filter',
+      },
+    ],
+  });
+
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await seedStorage(page, initialData);
+
+  await expectBlocked(page, targetUrl);
+  await expect(page.getByLabel('Responsible filter')).toContainText('Group Disabled Filter');
+
+  await seedStorage(page, {
+    ...initialData,
+    groups: initialData.groups.map((group) => ({ ...group, enabled: false })),
+  });
+
+  await expect.poll(() => page.url()).toBe(targetUrl);
+  await expect(page.getByText('Disabled group target allowed')).toBeVisible();
+});
+
 test('handles missing or stale block ids and no-op go back safely', async ({
   extensionPage,
   page,
@@ -139,11 +169,6 @@ test('handles missing or stale block ids and no-op go back safely', async ({
   const missingBlockPage = page.url();
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect.poll(() => page.url()).toBe(missingBlockPage);
-
-  await page.goto(
-    `${extensionPage(PAGES.BLOCKED)}?url=${encodeURIComponent('https://blocked.example.invalid')}`
-  );
-  await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
   await page.goto(`${extensionPage(PAGES.BLOCKED)}?blockId=missing-block`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -6,8 +6,10 @@ const mocks = vi.hoisted(() => ({
   continueFromTab: vi.fn(),
   getUrlDecision: vi.fn(),
   getBlockedPageStateByBlockId: vi.fn(),
+  getFreshBlockedPageStateByBlockId: vi.fn(),
   getFreshBlockedPageState: vi.fn(),
   goBackFromActiveTab: vi.fn(),
+  goBackFromBlockedPage: vi.fn(),
   goBackFromTab: vi.fn(),
   loadData: vi.fn(),
 }));
@@ -16,8 +18,10 @@ vi.mock('../../../src/background/tabController', () => ({
   getTabController: (): {
     getUrlDecision: typeof mocks.getUrlDecision;
     getBlockedPageStateByBlockId: typeof mocks.getBlockedPageStateByBlockId;
+    getFreshBlockedPageStateByBlockId: typeof mocks.getFreshBlockedPageStateByBlockId;
     getFreshBlockedPageState: typeof mocks.getFreshBlockedPageState;
     goBackFromActiveTab: typeof mocks.goBackFromActiveTab;
+    goBackFromBlockedPage: typeof mocks.goBackFromBlockedPage;
     goBackFromTab: typeof mocks.goBackFromTab;
     continueFromActiveTab: typeof mocks.continueFromActiveTab;
     continueFromBlockedPage: typeof mocks.continueFromBlockedPage;
@@ -28,8 +32,10 @@ vi.mock('../../../src/background/tabController', () => ({
     continueFromTab: mocks.continueFromTab,
     getUrlDecision: mocks.getUrlDecision,
     getBlockedPageStateByBlockId: mocks.getBlockedPageStateByBlockId,
+    getFreshBlockedPageStateByBlockId: mocks.getFreshBlockedPageStateByBlockId,
     getFreshBlockedPageState: mocks.getFreshBlockedPageState,
     goBackFromActiveTab: mocks.goBackFromActiveTab,
+    goBackFromBlockedPage: mocks.goBackFromBlockedPage,
     goBackFromTab: mocks.goBackFromTab,
   }),
 }));
@@ -60,8 +66,10 @@ describe('handleMessage', () => {
     mocks.continueFromTab.mockResolvedValue(false);
     mocks.getUrlDecision.mockResolvedValue({ action: 'allow', reason: 'no-match' });
     mocks.getBlockedPageStateByBlockId.mockResolvedValue({ status: 'unavailable' });
+    mocks.getFreshBlockedPageStateByBlockId.mockResolvedValue({ status: 'unavailable' });
     mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'unavailable' });
     mocks.goBackFromActiveTab.mockResolvedValue(false);
+    mocks.goBackFromBlockedPage.mockResolvedValue(false);
     mocks.goBackFromTab.mockResolvedValue(false);
   });
 
@@ -116,7 +124,7 @@ describe('handleMessage', () => {
   });
 
   it('uses the supplied block id for continue requests', async () => {
-    mocks.continueFromTab.mockResolvedValue(true);
+    mocks.continueFromBlockedPage.mockResolvedValue(true);
     const sendResponse = vi.fn();
 
     expect(
@@ -136,11 +144,8 @@ describe('handleMessage', () => {
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith({ continued: true });
     });
-    expect(mocks.continueFromTab).toHaveBeenCalledWith(
-      9,
-      'chrome-extension://test-extension-id/src/blocked/index.html?blockId=block-9',
-      'block-9'
-    );
+    expect(mocks.continueFromBlockedPage).toHaveBeenCalledWith('block-9');
+    expect(mocks.continueFromTab).not.toHaveBeenCalled();
   });
 
   it('continues by block id when the sender tab is unavailable', async () => {
@@ -207,6 +212,29 @@ describe('handleMessage', () => {
     expect(mocks.goBackFromActiveTab).not.toHaveBeenCalled();
   });
 
+  it('responds to go-back requests by block id without sender tab', async () => {
+    mocks.goBackFromBlockedPage.mockResolvedValue(true);
+    const sendResponse = vi.fn();
+
+    expect(
+      handleMessage(
+        { type: MessageType.GO_BACK_ACTIVE_TAB, blockId: 'block-10' },
+        {
+          id: 'test-extension-id',
+          url: 'chrome-extension://test-extension-id/src/blocked/index.html?blockId=block-10',
+        },
+        sendResponse
+      )
+    ).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(sendResponse).toHaveBeenCalledWith({ restored: true });
+    });
+    expect(mocks.goBackFromBlockedPage).toHaveBeenCalledWith('block-10');
+    expect(mocks.goBackFromActiveTab).not.toHaveBeenCalled();
+    expect(mocks.goBackFromTab).not.toHaveBeenCalled();
+  });
+
   it('responds to blocked-page state requests', async () => {
     const blockedState = {
       blockId: 'block-7',
@@ -257,7 +285,7 @@ describe('handleMessage', () => {
     );
   });
 
-  it('prefers fresh blocked-page state when sender tab is available', async () => {
+  it('prefers fresh blocked-page state by block id when one is available', async () => {
     const sendResponse = vi.fn();
 
     expect(
@@ -275,15 +303,13 @@ describe('handleMessage', () => {
     ).toBe(true);
 
     await vi.waitFor(() => {
-      expect(mocks.getFreshBlockedPageState).toHaveBeenCalledWith(
-        8,
-        'chrome-extension://test-extension-id/src/blocked/index.html?blockId=block-8'
-      );
+      expect(mocks.getFreshBlockedPageStateByBlockId).toHaveBeenCalledWith('block-8');
     });
+    expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
     expect(mocks.getBlockedPageStateByBlockId).not.toHaveBeenCalled();
   });
 
-  it('responds to blocked-page state requests by block id without sender tab', async () => {
+  it('responds to blocked-page state requests by freshly evaluating block id without sender tab', async () => {
     const response = {
       status: 'blocked',
       state: {
@@ -310,7 +336,7 @@ describe('handleMessage', () => {
         },
       },
     };
-    mocks.getBlockedPageStateByBlockId.mockResolvedValue(response);
+    mocks.getFreshBlockedPageStateByBlockId.mockResolvedValue(response);
     const sendResponse = vi.fn();
 
     expect(
@@ -326,7 +352,8 @@ describe('handleMessage', () => {
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith(response);
     });
-    expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith('block-8');
+    expect(mocks.getFreshBlockedPageStateByBlockId).toHaveBeenCalledWith('block-8');
+    expect(mocks.getBlockedPageStateByBlockId).not.toHaveBeenCalled();
     expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
   });
 

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -320,6 +320,59 @@ describe('TabController', () => {
     });
   });
 
+  it('restores a blocked page when current rules allow its block id target', async () => {
+    const chromeMock = getChromeMock();
+    const targetUrl = 'https://blocked-disabled-group.com/focus';
+    const initialData = createStorageData({
+      groups: [
+        {
+          id: DEFAULT_GROUP_ID,
+          name: '24/7',
+          schedules: [],
+          is24x7: true,
+          enabled: true,
+        },
+      ],
+      filters: [
+        {
+          id: 'disabled-group-filter',
+          pattern: 'blocked-disabled-group.com',
+          groupId: DEFAULT_GROUP_ID,
+          enabled: true,
+          matchMode: 'contains',
+        },
+      ],
+      rulesVersion: 12,
+    });
+    chromeMock.storage.sync._data.set(STORAGE_KEY, initialData);
+
+    const { getTabController } = await import('../../../src/background/tabController');
+    await getTabController().evaluateNavigation(12, targetUrl);
+    const blockedState = await getBlockedTabState(12);
+    expect(blockedState?.blockId).toEqual(expect.any(String));
+
+    chromeMock.storage.sync._data.set(
+      STORAGE_KEY,
+      createStorageData({
+        ...initialData,
+        groups: initialData.groups.map((group) => ({ ...group, enabled: false })),
+        rulesVersion: 13,
+      })
+    );
+    chromeMock.tabs.update.mockClear();
+
+    await expect(
+      getTabController().getFreshBlockedPageState(12, blockedPageUrl(blockedState!.blockId))
+    ).resolves.toEqual({ status: 'allowed', targetUrl });
+    expect(chromeMock.tabs.update).toHaveBeenCalledWith(
+      12,
+      { url: targetUrl },
+      expect.any(Function)
+    );
+    await expect(getBlockedTabState(12)).resolves.toBeUndefined();
+    await expect(getLastAllowedUrl(12)).resolves.toBe(targetUrl);
+  });
+
   it('re-evaluates a blocked page as warning when rules change from hard block to warning', async () => {
     const chromeMock = getChromeMock();
     chromeMock.storage.sync._data.set(

--- a/test/unit/shared/messages.test.ts
+++ b/test/unit/shared/messages.test.ts
@@ -19,6 +19,12 @@ describe('shared/types/messages', () => {
     );
     expect(isCheckUrlMessage({ type: MessageType.CHECK_URL, url: 42 })).toBe(false);
     expect(isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB })).toBe(true);
+    expect(
+      isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB, blockId: 'block-1' })
+    ).toBe(true);
+    expect(isGoBackActiveTabMessage({ type: MessageType.GO_BACK_ACTIVE_TAB, blockId: 42 })).toBe(
+      false
+    );
     expect(isContinueActiveTabMessage({ type: MessageType.CONTINUE_ACTIVE_TAB })).toBe(true);
     expect(
       isContinueActiveTabMessage({ type: MessageType.CONTINUE_ACTIVE_TAB, blockId: 'block-1' })


### PR DESCRIPTION
## Summary
- route blocked-page state lookups through canonical block ids so extension pages do not depend on unreliable sender tab context
- re-evaluate block-id state against fresh rules so disabled groups no longer leave stale blocked-page details active
- make the VS Code F5 profile launch cleanly by removing stale Chrome session/cache state and clearing the debug profile crash marker while preserving extension settings

## Root Cause
F5 was loading the latest built extension, but the persistent Chrome debug profile restored stale blocked-page tabs and kept Chrome's crashed-session marker. Those restored pages still had the old `?url=` blocked-page URL, which made the debug session look like it was running old code and showed `Block details unavailable`. Separately, extension-page runtime messages needed to resolve state by `blockId` because `sender.tab` is not reliable from the blocked page.

## Validation
- `npm run typecheck`
- `npm run typecheck:test`
- `npm run build:dev`
- `npm run lint`
- `npm exec prettier -- --check .vscode/launch.json .vscode/tasks.json`
- `npm exec playwright -- test test/e2e/blocked.spec.ts`
- Verified with Computer Use in the actual VS Code/Chrome F5 flow: after stopping the prior debug session and pressing F5, Chrome opened one clean `about:blank` tab with no restore prompt; navigating to `https://www.google.com/search?q=asdf` blocked with `?blockId=...` and rendered the responsible filter details.

Closes #104
