### PR TITLE
Add .gitattributes to normalize line endings to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Normalize line endings: store text files with LF in the repo and check
+# them out with LF in every working tree, regardless of core.autocrlf.
+# Keeps Prettier's default endOfLine: "lf" green on Windows checkouts.
+* text=auto eol=lf
+
+# Binary assets git should never touch.
+*.png binary
+*.zip binary
+*.svg text eol=lf


### PR DESCRIPTION
## Summary
Adds a `.gitattributes` that forces text files to check out with **LF** in every working tree, overriding `core.autocrlf`. PNG/ZIP assets stay binary.

## Why
The repo has no `.gitattributes` and Windows clones typically run `core.autocrlf=true`, so the working tree gets CRLF while Prettier defaults to `endOfLine: "lf"`. That makes `npm run format:check` fail locally on every text file (41 of them) even though the committed blobs are LF and CI (Linux) passes. This pins LF everywhere so local and CI behavior match.

## Verification
After re-applying attributes to the working tree:
- `src/shared/constants.ts` line endings: CRLF → LF
- `prettier . --check` → **"All matched files use Prettier code style!"** (previously failed on 41 files)

Independent of #107 — branched off `main`.