### PR TITLE
Stabilize flaky Playwright e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,12 +4,28 @@ export default defineConfig({
   testDir: './test/e2e',
   fullyParallel: false,
   workers: 1,
+  // Retry on CI only. The e2e suite drives a real MV3 service worker whose
+  // event-driven wake/reconcile timing is inherently non-deterministic under
+  // load; retries are a backstop for that residual jitter, not a substitute for
+  // the determinism fixes. Kept at 0 locally so flakiness stays visible.
+  retries: process.env.CI ? 2 : 0,
   reporter: process.env.CI
-    ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
+    ? [['list'], ['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
     : 'list',
   timeout: 30_000,
+  // Most e2e assertions wait for the background service worker to wake, react to
+  // a storage change, and reconcile open tabs. Playwright's default 5s expect
+  // timeout is too tight for that path under CI/heavy load; widen it while
+  // keeping the 30s per-test ceiling so a genuinely stuck run still fails fast.
+  expect: {
+    timeout: 15_000,
+  },
   use: {
     headless: true,
-    trace: 'retain-on-failure',
+    // NOTE: the e2e fixtures launch their own persistent context (required to
+    // load the unpacked extension), so Playwright's built-in artifact wiring
+    // (trace/video/navigationTimeout from `use`) does not apply here. Tracing
+    // and navigation timeouts are configured directly on the context in
+    // test/e2e/fixtures.ts instead.
   },
 });

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -51,10 +51,8 @@ test('go back restores the last allowed url', async ({
   await expectBlocked(page, blockedUrl);
   await captureScreenshot(page, testInfo, 'blocked-page.png');
 
-  await Promise.all([
-    page.waitForURL(allowedUrl),
-    page.getByRole('button', { name: 'Go Back' }).click(),
-  ]);
+  await page.getByRole('button', { name: 'Go Back' }).click();
+  await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(allowedUrl);
   await expect(page.getByText('Allowed page')).toBeVisible();
 });
 
@@ -100,7 +98,7 @@ test('renders the blocked url and responsible filter from block id state', async
 });
 
 test('warning blocks show Continue and allow same-tab bypass', async ({ extensionPage, page }) => {
-  const targetUrl = 'https://example.com/warning-focus';
+  const targetUrl = 'https://warning-bypass.example.test/warning-focus';
   await mockAllowedPage(page, targetUrl, 'Warning bypass allowed');
 
   await page.goto(extensionPage(PAGES.OPTIONS));
@@ -111,7 +109,7 @@ test('warning blocks show Continue and allow same-tab bypass', async ({ extensio
       filters: [
         {
           id: 'warning-filter',
-          pattern: 'example.com/warning',
+          pattern: 'warning-bypass.example.test/warning',
           groupId: defaultGroup.id,
           enabled: true,
           matchMode: 'contains',

--- a/test/e2e/extension.spec.ts
+++ b/test/e2e/extension.spec.ts
@@ -155,10 +155,8 @@ for (const navigationMethod of ['push-state', 'replace-state'] as const) {
     await expectBlockedSameTabNavigation(page, targetUrl);
     await captureScreenshot(page, testInfo, `${navigationMethod}-blocked-page.png`);
 
-    await Promise.all([
-      page.waitForURL(initialUrl),
-      page.getByRole('button', { name: 'Go Back' }).click(),
-    ]);
+    await page.getByRole('button', { name: 'Go Back' }).click();
+    await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(initialUrl);
     await expect(page.getByRole('heading', { name: 'SPA Route Test' })).toBeVisible();
     await expect(page.locator('#current-url')).toHaveText(initialUrl);
   });
@@ -198,10 +196,8 @@ test('blocks matching same-tab hash navigations and preserves go back', async ({
   await expectBlockedSameTabNavigation(page, targetUrl);
   await captureScreenshot(page, testInfo, 'hash-blocked-page.png');
 
-  await Promise.all([
-    page.waitForURL(initialUrl),
-    page.getByRole('button', { name: 'Go Back' }).click(),
-  ]);
+  await page.getByRole('button', { name: 'Go Back' }).click();
+  await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(initialUrl);
   await expect(page.getByRole('heading', { name: 'SPA Route Test' })).toBeVisible();
   await expect(page.locator('#current-url')).toHaveText(initialUrl);
 });

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -10,6 +10,43 @@ interface ExtensionFixtures {
   page: Page;
 }
 
+// Stub every otherwise-unmocked http(s) navigation/subresource with a local 200
+// so tests never depend on real DNS or network. This removes the dominant flaky
+// failure (net::ERR_NAME_NOT_RESOLVED) for the non-resolving *.example.test /
+// *.example.invalid domains the suite uses: a request that a per-test mock does
+// not cover (favicon, subresources, sibling/redirect URLs) no longer falls
+// through to real DNS with variable CI latency.
+//
+// Safe by construction:
+// - Per-test routes (registered later in the test body) take precedence, since
+//   Playwright matches the most recently registered route first.
+// - Extension/internal URLs are passed through untouched so extension pages,
+//   chunks, and the blocked page load normally.
+// - It cannot defeat a block assertion: blocking is driven by chrome.tabs.update
+//   redirecting the tab to blocked.html, independent of whether the original
+//   request succeeded, so a stubbed 200 is still redirected.
+async function installDeterministicNetwork(context: BrowserContext): Promise<void> {
+  await context.route('**/*', async (route) => {
+    const url = route.request().url();
+    if (
+      url.startsWith('chrome-extension://') ||
+      url.startsWith('chrome://') ||
+      url.startsWith('about:') ||
+      url.startsWith('data:') ||
+      url.startsWith('blob:')
+    ) {
+      await route.continue();
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'text/html',
+      body: '<!doctype html><title>stub</title><main>stub</main>',
+    });
+  });
+}
+
 export const test = base.extend<ExtensionFixtures>({
   context: async ({ browserName: _browserName }, use) => {
     const extensionPath = path.resolve('.output', 'chrome-mv3');
@@ -21,9 +58,40 @@ export const test = base.extend<ExtensionFixtures>({
       args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
     });
 
+    // Give navigations a generous-but-bounded ceiling. The persistent context is
+    // launched directly, so `use.navigationTimeout` from the config does not
+    // apply and must be set here.
+    context.setDefaultNavigationTimeout(15_000);
+
+    await installDeterministicNetwork(context);
+
+    // Capture a trace only while retrying a failed test, so residual flakiness
+    // stays diagnosable without paying per-action screenshot/snapshot overhead
+    // on the (common) first attempt — that overhead is itself a flakiness source
+    // under load. Done manually because `use.trace` does not apply to a
+    // directly-launched persistent context; this mirrors `trace: on-first-retry`.
+    const captureTrace = base.info().retry > 0;
+    if (captureTrace) {
+      await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+    }
+
     try {
       await use(context);
     } finally {
+      if (captureTrace) {
+        try {
+          const testInfo = base.info();
+          if (testInfo.status !== testInfo.expectedStatus) {
+            const tracePath = testInfo.outputPath('trace.zip');
+            await context.tracing.stop({ path: tracePath });
+            await testInfo.attach('trace', { path: tracePath, contentType: 'application/zip' });
+          } else {
+            await context.tracing.stop();
+          }
+        } catch {
+          // Tracing teardown is best-effort and must never mask a test result.
+        }
+      }
       await context.close();
       await rm(userDataDir, { recursive: true, force: true });
     }

--- a/test/e2e/lifecycle.spec.ts
+++ b/test/e2e/lifecycle.spec.ts
@@ -319,11 +319,11 @@ test('adding a whitelist from blocked state restores the target and clears stale
       )
     )
     .toBe(true);
-  await browsingPage.reload().catch((error: unknown) => {
-    if (browsingPage.url() !== targetUrl) {
-      throw error;
-    }
-  });
+  // The background reconcile restores the already-open blocked tab on its own
+  // once the whitelist lands (same as the primed-storage and popup-disable
+  // siblings). Do not reload manually: a manual reload races the background's
+  // tab navigation and intermittently fails with "Not attached to an active
+  // page" under load.
   await expect.poll(() => browsingPage.url()).toBe(targetUrl);
   await expect(browsingPage.getByText('Blocked whitelist restored')).toBeVisible();
   await expectBlockedTabStateCleared(page, targetUrl);


### PR DESCRIPTION
## Problem

The **Extension E2E** job fails intermittently in CI and goes green on retry — classic flakiness, not real regressions. Pulling the actual failure logs from past runs surfaced three recurring signatures, all rooted in timing/network nondeterminism around the MV3 service worker:

1. `net::ERR_NAME_NOT_RESOLVED` — a navigation to a non-resolving test domain (`*.example.test` / `*.example.invalid`) escaped its per-test `context.route` mock and hit real DNS.
2. `Test timeout of 30000ms exceeded` on `expectBlocked`/`expectAllowed` — Playwright's hidden **5s** default `expect` timeout is too tight for the path "wake the service worker → react to a storage change → reconcile open tabs" under CI load.
3. `page.reload: Not attached to an active page` — in the whitelist-from-blocked test, a manual `page.reload()` raced the background's own tab restore.

## Changes

**`test/e2e/fixtures.ts`**
- **Deterministic network**: a context-level catch-all route stubs every otherwise-unmocked `http(s)` request with a local `200`, so no test depends on real DNS. Per-test `mockAllowedPage` routes still win (Playwright matches the most-recently-registered route first), and block assertions are unaffected because blocking is driven by `chrome.tabs.update` redirecting to `blocked.html` regardless of the original request. Extension/internal URLs pass through untouched.
- Set a 15s navigation timeout on the context and capture a trace **on retry only**. Both are done directly on the context because the suite launches its **own** persistent context (to load the unpacked extension), so Playwright's built-in `use.trace` / `use.navigationTimeout` wiring does not apply. Tracing on retry avoids per-action screenshot overhead on the common path — that overhead is itself a flake source under load.

**`playwright.config.ts`**
- `expect.timeout: 15_000` (the single highest-leverage fix for signatures #2/#3), keeping the 30s per-test ceiling so a genuinely stuck run still fails fast.
- `retries: process.env.CI ? 2 : 0` as a backstop for residual MV3 wake jitter — kept at 0 locally so flakiness stays visible in development.
- Added the `list` reporter on CI so retried/flaky tests stream into the log.

**`test/e2e/blocked.spec.ts` / `test/e2e/extension.spec.ts`**
- Replaced the suite's only real, resolvable domain (`example.com`) in the warning-bypass test with a non-resolving stub, removing a dependency on CI egress/DNS.
- Converted the three Go-Back `Promise.all([page.waitForURL(target), click()])` sites to click-then-`expect.poll(() => page.url())`. `waitForURL` is bound to the navigation lifecycle and rejects on a transient failed navigation; polling the committed URL tolerates the service worker settling a beat later. All content assertions are retained (a URL alone is weaker than verifying the restored page rendered).

**`test/e2e/lifecycle.spec.ts`**
- Dropped the redundant manual `browsingPage.reload()` in the whitelist-from-blocked test and rely on the background reconcile to restore the open tab — matching the `primed-storage` and `popup-disable` sibling tests. The manual reload raced the background's own tab navigation and produced the `Not attached to an active page` failure.

## Validation

Reproduced and fixed locally under sustained heavy CPU load (cores saturated with busy workers — a quiet machine passes even when CI is flaky):

- **Before:** the whitelist-from-blocked race reproduced under load.
- **After:** 3 consecutive full-suite runs (40/40 each) **and** a `--repeat-each=3` interleaved run (120/120) — all green.

No product code changed; this is test-infrastructure hardening only. The fixes target root causes (determinism + adequate timeouts); retries remain a thin backstop, so a genuine regression that fails all attempts still reds the build.
