### PR TITLE
Hide block page details and actions behind a Learn more link

### DIFF
--- a/src/entrypoints/blocked/index.html
+++ b/src/entrypoints/blocked/index.html
@@ -11,35 +11,46 @@
       <img class="icon" src="/assets/icons/icon.svg" alt="" aria-hidden="true" />
       <h1>Page Blocked</h1>
       <p>This page has been blocked by Teichos based on your filter settings.</p>
-      <div class="url" id="blocked-url" role="status" aria-label="Blocked URL"></div>
-      <section class="details" id="responsible-filter" aria-label="Responsible filter" hidden>
-        <dl>
-          <div>
-            <dt>Filter</dt>
-            <dd id="responsible-filter-name"></dd>
-          </div>
-          <div>
-            <dt>Pattern</dt>
-            <dd id="responsible-filter-pattern"></dd>
-          </div>
-          <div>
-            <dt>Match</dt>
-            <dd id="responsible-filter-match"></dd>
-          </div>
-          <div>
-            <dt>Group</dt>
-            <dd id="responsible-filter-group"></dd>
-          </div>
-          <div>
-            <dt>Schedule</dt>
-            <dd id="responsible-filter-schedule"></dd>
-          </div>
-        </dl>
-      </section>
-      <div class="actions">
-        <button class="button" id="continue" type="button" hidden>Continue</button>
-        <button class="button" id="go-back" type="button">Go Back</button>
-        <button class="button secondary" id="open-options" type="button">Manage Filters</button>
+      <button
+        class="learn-more"
+        id="learn-more"
+        type="button"
+        aria-expanded="false"
+        aria-controls="block-extras"
+      >
+        Learn more
+      </button>
+      <div id="block-extras" hidden>
+        <div class="url" id="blocked-url" role="status" aria-label="Blocked URL"></div>
+        <section class="details" id="responsible-filter" aria-label="Responsible filter" hidden>
+          <dl>
+            <div>
+              <dt>Filter</dt>
+              <dd id="responsible-filter-name"></dd>
+            </div>
+            <div>
+              <dt>Pattern</dt>
+              <dd id="responsible-filter-pattern"></dd>
+            </div>
+            <div>
+              <dt>Match</dt>
+              <dd id="responsible-filter-match"></dd>
+            </div>
+            <div>
+              <dt>Group</dt>
+              <dd id="responsible-filter-group"></dd>
+            </div>
+            <div>
+              <dt>Schedule</dt>
+              <dd id="responsible-filter-schedule"></dd>
+            </div>
+          </dl>
+        </section>
+        <div class="actions">
+          <button class="button" id="continue" type="button" hidden>Continue</button>
+          <button class="button" id="go-back" type="button">Go Back</button>
+          <button class="button secondary" id="open-options" type="button">Manage Filters</button>
+        </div>
       </div>
     </div>
     <script src="./index.ts" type="module"></script>

--- a/src/entrypoints/blocked/index.ts
+++ b/src/entrypoints/blocked/index.ts
@@ -5,6 +5,7 @@
 
 import { sendExtensionMessage } from '../../shared/api/messaging';
 import { openOptionsPage } from '../../shared/api/runtime';
+import { loadData } from '../../shared/api/storage';
 import {
   MessageType,
   type BlockedPageState,
@@ -20,12 +21,13 @@ interface BlockedPageViewModel {
   readonly state?: BlockedPageState;
 }
 
+/** Once the user clicks "Learn more", keep the extras open across re-renders. */
+let learnMoreClicked = false;
+
 /**
  * Initialize blocked page
  */
 async function init(): Promise<void> {
-  await renderPage();
-
   const goBackButton = getElementByIdOrNull('go-back');
   goBackButton?.addEventListener('click', () => {
     void handleGoBack().catch((error: unknown) => {
@@ -38,6 +40,12 @@ async function init(): Promise<void> {
     void handleContinue().catch((error: unknown) => {
       console.error('Failed to continue past warning:', error);
     });
+  });
+
+  const learnMoreButton = getElementByIdOrNull('learn-more');
+  learnMoreButton?.addEventListener('click', () => {
+    learnMoreClicked = true;
+    setExtrasExpanded(true);
   });
 
   // Set up options button
@@ -55,6 +63,8 @@ async function init(): Promise<void> {
 
     void renderPage();
   });
+
+  await renderPage();
 }
 
 async function renderPage(): Promise<void> {
@@ -62,6 +72,41 @@ async function renderPage(): Promise<void> {
   renderBlockedUrl(state);
   renderResponsibleFilter(state);
   renderActions(state);
+  await renderExtrasExpansion();
+}
+
+/**
+ * Details and action buttons stay collapsed behind the "Learn more" link unless the user has
+ * expanded them or the global "expand details by default" setting is enabled.
+ */
+async function renderExtrasExpansion(): Promise<void> {
+  if (learnMoreClicked) {
+    setExtrasExpanded(true);
+    return;
+  }
+
+  let expandByDefault = false;
+  try {
+    const data = await loadData();
+    expandByDefault = data.expandBlockPageDetails === true;
+  } catch (error: unknown) {
+    console.warn('[Teichos] Failed to load block page display settings:', error);
+  }
+
+  setExtrasExpanded(expandByDefault);
+}
+
+function setExtrasExpanded(expanded: boolean): void {
+  const extras = getElementByIdOrNull<HTMLElement>('block-extras');
+  if (extras) {
+    extras.hidden = !expanded;
+  }
+
+  const learnMoreButton = getElementByIdOrNull<HTMLButtonElement>('learn-more');
+  if (learnMoreButton) {
+    learnMoreButton.hidden = expanded;
+    learnMoreButton.setAttribute('aria-expanded', String(expanded));
+  }
 }
 
 async function getBlockedPageState(): Promise<BlockedPageViewModel> {

--- a/src/entrypoints/blocked/styles/blocked.css
+++ b/src/entrypoints/blocked/styles/blocked.css
@@ -87,6 +87,34 @@ p {
   font-size: var(--text-md);
 }
 
+.learn-more {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0 0 0.5rem;
+  color: var(--text-on-bg);
+  font: inherit;
+  font-size: var(--text-md);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  opacity: 0.85;
+}
+
+.learn-more:hover {
+  opacity: 1;
+}
+
+.learn-more:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+.learn-more[hidden] {
+  display: none;
+}
+
 .details {
   margin: 0 0 2rem;
   padding: 1rem;

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -145,6 +145,12 @@
                 <option value="warning">Warning</option>
               </select>
             </div>
+            <div class="form-row">
+              <label class="checkbox-label">
+                <input type="checkbox" id="global-expand-details" />
+                Expand block page details by default
+              </label>
+            </div>
             <div class="global-settings-actions">
               <button class="button secondary" id="preview-block-btn" type="button">
                 Preview Block Page

--- a/src/entrypoints/options/index.ts
+++ b/src/entrypoints/options/index.ts
@@ -106,6 +106,12 @@ function setupEventListeners(): void {
   getElementByIdOrNull<HTMLSelectElement>('global-block-type')?.addEventListener('change', () => {
     void handleGlobalBlockTypeChange();
   });
+  getElementByIdOrNull<HTMLInputElement>('global-expand-details')?.addEventListener(
+    'change',
+    () => {
+      void handleGlobalExpandDetailsChange();
+    }
+  );
 
   // Filter modal
   getElementByIdOrNull('close-filter-modal')?.addEventListener('click', closeFilterModal);
@@ -330,6 +336,11 @@ function renderGlobalSettings(data: StorageData): void {
   if (blockTypeSelect) {
     blockTypeSelect.value = data.blockType === 'warning' ? 'warning' : 'block';
   }
+
+  const expandDetailsCheckbox = getElementByIdOrNull<HTMLInputElement>('global-expand-details');
+  if (expandDetailsCheckbox) {
+    expandDetailsCheckbox.checked = data.expandBlockPageDetails === true;
+  }
 }
 
 async function handleGlobalBlockTypeChange(): Promise<void> {
@@ -342,6 +353,21 @@ async function handleGlobalBlockTypeChange(): Promise<void> {
   } catch (error) {
     console.error('Failed to update global block type:', error);
     setGlobalSettingsStatus('Failed to update block type.', true);
+    renderGlobalSettings(await loadData());
+  }
+}
+
+async function handleGlobalExpandDetailsChange(): Promise<void> {
+  const expandBlockPageDetails =
+    getElementByIdOrNull<HTMLInputElement>('global-expand-details')?.checked === true;
+
+  try {
+    const data = await loadData();
+    await saveData({ ...data, expandBlockPageDetails });
+    setGlobalSettingsStatus('Block page details preference updated.');
+  } catch (error) {
+    console.error('Failed to update block page details preference:', error);
+    setGlobalSettingsStatus('Failed to update block page details preference.', true);
     renderGlobalSettings(await loadData());
   }
 }

--- a/src/shared/storage/defaults.ts
+++ b/src/shared/storage/defaults.ts
@@ -18,6 +18,7 @@ export function createDefaultData(): StorageData {
     whitelist: [],
     snooze: { active: false },
     blockType: 'block',
+    expandBlockPageDetails: false,
     rulesVersion: 0,
   };
 }

--- a/src/shared/storage/importExport.ts
+++ b/src/shared/storage/importExport.ts
@@ -122,6 +122,13 @@ function validateImportedStorageShape(raw: JsonObject): void {
   if (raw['blockType'] !== undefined && !isValidBlockType(raw['blockType'])) {
     throw new Error('Settings file contains an invalid block type.');
   }
+
+  if (
+    raw['expandBlockPageDetails'] !== undefined &&
+    typeof raw['expandBlockPageDetails'] !== 'boolean'
+  ) {
+    throw new Error('Settings file contains an invalid block page details preference.');
+  }
 }
 
 export function serializeDataForExport(data: StorageData): string {

--- a/src/shared/storage/normalize.ts
+++ b/src/shared/storage/normalize.ts
@@ -30,6 +30,7 @@ export interface LegacyStorageData {
   readonly whitelist?: readonly LegacyWhitelist[];
   readonly rulesVersion?: number;
   readonly blockType?: BlockType;
+  readonly expandBlockPageDetails?: boolean;
   readonly snooze?: {
     readonly active?: boolean;
     readonly until?: number;
@@ -99,6 +100,7 @@ export function normalizeStoredData(raw: LegacyStorageData | undefined): Storage
       ? raw.rulesVersion
       : 0;
   const blockType = isValidBlockType(raw.blockType) ? raw.blockType : 'block';
+  const expandBlockPageDetails = raw.expandBlockPageDetails === true;
 
   return {
     groups,
@@ -106,6 +108,7 @@ export function normalizeStoredData(raw: LegacyStorageData | undefined): Storage
     whitelist,
     snooze,
     blockType,
+    expandBlockPageDetails,
     rulesVersion,
   };
 }

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -108,6 +108,7 @@ export interface StorageData {
   readonly whitelist: readonly Whitelist[];
   readonly snooze: SnoozeState;
   readonly blockType?: BlockType;
+  readonly expandBlockPageDetails?: boolean;
   readonly rulesVersion: number;
 }
 

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -6,7 +6,9 @@ import {
   expectAllowed,
   expectBlocked,
   mockAllowedPage,
+  readStorage,
   seedStorage,
+  showBlockPageDetails,
   waitForOptionsReady,
 } from './helpers';
 import { PAGES } from '../../src/shared/constants';
@@ -52,6 +54,7 @@ test('go back restores the last allowed url', async ({
   await expectBlocked(page, blockedUrl);
   await captureScreenshot(page, testInfo, 'blocked-page.png');
 
+  await showBlockPageDetails(page);
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(allowedUrl);
   await expect(page.getByText('Allowed page')).toBeVisible();
@@ -59,6 +62,7 @@ test('go back restores the last allowed url', async ({
 
 test('opens settings from the blocked page', async ({ context, extensionPage, page }) => {
   await page.goto(extensionPage(PAGES.BLOCKED));
+  await showBlockPageDetails(page);
 
   const optionsPagePromise = context.waitForEvent('page');
   await page.getByRole('button', { name: 'Manage Filters' }).click();
@@ -94,6 +98,7 @@ test('renders the blocked url and responsible filter from block id state', async
   );
 
   await expectBlocked(page, targetUrl);
+  await showBlockPageDetails(page);
   await expect(page.getByLabel('Responsible filter')).toContainText('Blocked State');
   await expect(page.getByLabel('Responsible filter')).toContainText('blocked-state.example.test');
 });
@@ -121,6 +126,7 @@ test('warning blocks show Continue and allow same-tab bypass', async ({ extensio
   );
 
   await expectBlocked(page, targetUrl);
+  await showBlockPageDetails(page);
   await expect(page.getByRole('button', { name: 'Continue' })).toBeVisible();
 
   await page.getByRole('button', { name: 'Continue' }).click();
@@ -132,6 +138,7 @@ test('renders a sample block for each preview block type', async ({ extensionPag
   await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText('https://www.example.com/');
+  await showBlockPageDetails(page);
   await expect(page.getByLabel('Responsible filter')).toContainText('Example filter');
   await expect(page.getByLabel('Responsible filter')).toContainText('example.com');
   await expect(page.getByLabel('Responsible filter')).toContainText('Example group');
@@ -139,7 +146,47 @@ test('renders a sample block for each preview block type', async ({ extensionPag
 
   await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=warning`);
   await expect(page.getByLabel('Blocked URL')).toHaveText('https://www.example.com/');
+  await showBlockPageDetails(page);
   await expect(page.locator('#continue')).toBeVisible();
+});
+
+test('hides details and actions behind the Learn more link by default', async ({
+  extensionPage,
+  page,
+}) => {
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
+  await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+
+  const learnMore = page.getByRole('button', { name: 'Learn more' });
+  await expect(learnMore).toBeVisible();
+  await expect(page.getByLabel('Blocked URL')).toBeHidden();
+  await expect(page.getByLabel('Responsible filter')).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Go Back' })).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Manage Filters' })).toBeHidden();
+
+  await learnMore.click();
+  await expect(page.getByLabel('Blocked URL')).toBeVisible();
+  await expect(page.getByLabel('Responsible filter')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Go Back' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Manage Filters' })).toBeVisible();
+  await expect(learnMore).toBeHidden();
+});
+
+test('expands details by default when the global setting is enabled', async ({
+  extensionPage,
+  page,
+}) => {
+  await page.goto(extensionPage(PAGES.OPTIONS));
+  await waitForOptionsReady(page);
+  await page.locator('#global-expand-details').check();
+  await expect.poll(async () => (await readStorage(page))?.expandBlockPageDetails).toBe(true);
+
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
+  await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
+  await expect(page.getByLabel('Blocked URL')).toBeVisible();
+  await expect(page.getByLabel('Responsible filter')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Go Back' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Learn more' })).toBeHidden();
 });
 
 test('previews the block page from the options global settings', async ({
@@ -159,6 +206,7 @@ test('previews the block page from the options global settings', async ({
   await expect.poll(() => new URL(previewPage.url()).pathname).toBe(`/${PAGES.BLOCKED}`);
   await expect(previewPage.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(previewPage.getByLabel('Blocked URL')).toHaveText('https://www.example.com/');
+  await showBlockPageDetails(previewPage);
   await expect(previewPage.locator('#continue')).toBeVisible();
 });
 
@@ -170,6 +218,7 @@ test('handles missing or stale block ids and no-op go back safely', async ({
   await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
   const missingBlockPage = page.url();
+  await showBlockPageDetails(page);
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect.poll(() => page.url()).toBe(missingBlockPage);
 
@@ -183,6 +232,7 @@ test('handles missing or stale block ids and no-op go back safely', async ({
   await expect(page.getByLabel('Blocked URL')).toHaveText('Block details unavailable');
 
   const staleBlockPage = page.url();
+  await showBlockPageDetails(page);
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect.poll(() => page.url()).toBe(staleBlockPage);
 });

--- a/test/e2e/extension.spec.ts
+++ b/test/e2e/extension.spec.ts
@@ -6,6 +6,7 @@ import {
   defaultGroup,
   readStorage,
   seedStorage,
+  showBlockPageDetails,
 } from './helpers';
 import { PAGES } from '../../src/shared/constants';
 
@@ -61,7 +62,6 @@ async function expectBlockedSameTabNavigation(page: Page, targetUrl: string): Pr
     .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
-  await expect(page.getByLabel('Responsible filter')).toBeVisible();
 }
 
 test('loads the extension service worker and extension pages', async ({
@@ -117,6 +117,7 @@ test('redirects matching top-level navigations to the blocked page', async ({
     .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await showBlockPageDetails(page);
   await expect(page.getByLabel('Responsible filter')).toContainText('E2E Block');
 });
 
@@ -155,6 +156,7 @@ for (const navigationMethod of ['push-state', 'replace-state'] as const) {
     await expectBlockedSameTabNavigation(page, targetUrl);
     await captureScreenshot(page, testInfo, `${navigationMethod}-blocked-page.png`);
 
+    await showBlockPageDetails(page);
     await page.getByRole('button', { name: 'Go Back' }).click();
     await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(initialUrl);
     await expect(page.getByRole('heading', { name: 'SPA Route Test' })).toBeVisible();
@@ -196,6 +198,7 @@ test('blocks matching same-tab hash navigations and preserves go back', async ({
   await expectBlockedSameTabNavigation(page, targetUrl);
   await captureScreenshot(page, testInfo, 'hash-blocked-page.png');
 
+  await showBlockPageDetails(page);
   await page.getByRole('button', { name: 'Go Back' }).click();
   await expect.poll(() => page.url(), { timeout: 15_000 }).toBe(initialUrl);
   await expect(page.getByRole('heading', { name: 'SPA Route Test' })).toBeVisible();

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -27,6 +27,7 @@ export function createStorageData(overrides: Partial<StorageData> = {}): Storage
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
     blockType: overrides.blockType ?? 'block',
+    expandBlockPageDetails: overrides.expandBlockPageDetails ?? false,
     rulesVersion: overrides.rulesVersion ?? 0,
   };
 }
@@ -63,7 +64,15 @@ export async function expectBlocked(page: Page, targetUrl: string): Promise<void
     .toBe(true);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText(targetUrl);
-  await expect(page.getByLabel('Responsible filter')).toBeVisible();
+}
+
+/**
+ * Expand the block page details and action buttons, which are collapsed behind the
+ * "Learn more" link unless the global expand-by-default setting is enabled.
+ */
+export async function showBlockPageDetails(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Learn more' }).click();
+  await expect(page.locator('#block-extras')).toBeVisible();
 }
 
 export async function expectAllowed(page: Page, targetUrl: string): Promise<void> {

--- a/test/e2e/lifecycle.spec.ts
+++ b/test/e2e/lifecycle.spec.ts
@@ -19,6 +19,7 @@ import {
   readBlockedTabStateForTarget,
   readStorage,
   seedStorage,
+  showBlockPageDetails,
   toggleFilterViaOptions,
 } from './helpers';
 
@@ -498,6 +499,7 @@ test('editing a schedule through options changes navigation from off-schedule al
     .toBe(true);
   await expect(browsingPage.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(browsingPage.getByLabel('Blocked URL')).toHaveText(targetUrl);
+  await showBlockPageDetails(browsingPage);
   await expect(browsingPage.getByLabel('Responsible filter')).toContainText(
     'Schedule Lifecycle Filter'
   );

--- a/test/unit/background/rulesProvider.test.ts
+++ b/test/unit/background/rulesProvider.test.ts
@@ -229,6 +229,7 @@ describe('RulesProvider', () => {
       whitelist: [],
       snooze: { active: false },
       blockType: 'block',
+      expandBlockPageDetails: false,
       rulesVersion: 0,
     });
     expect(cachedRules).toBe(rules);

--- a/test/unit/background/snooze.test.ts
+++ b/test/unit/background/snooze.test.ts
@@ -66,6 +66,7 @@ describe('registerSnoozeHandlers', () => {
         whitelist: [],
         snooze: { active: false },
         blockType: 'block',
+        expandBlockPageDetails: false,
         rulesVersion: 1,
       });
     });
@@ -148,6 +149,7 @@ describe('registerSnoozeHandlers', () => {
         whitelist: [],
         snooze: { active: false },
         blockType: 'block',
+        expandBlockPageDetails: false,
         rulesVersion: 2,
       });
     });

--- a/test/unit/shared/storage.test.ts
+++ b/test/unit/shared/storage.test.ts
@@ -36,6 +36,7 @@ describe('storage', () => {
         whitelist: [],
         snooze: { active: false },
         blockType: 'block',
+        expandBlockPageDetails: false,
         rulesVersion: 0,
       });
     });
@@ -63,6 +64,7 @@ describe('storage', () => {
         whitelist: [],
         snooze: { active: false },
         blockType: 'warning' as const,
+        expandBlockPageDetails: true,
         rulesVersion: 2,
       };
 
@@ -246,6 +248,7 @@ describe('storage', () => {
         ],
         snooze: { active: true },
         blockType: 'block',
+        expandBlockPageDetails: false,
         rulesVersion: 0,
       });
     });
@@ -267,6 +270,27 @@ describe('storage', () => {
       const data = await loadData();
       expect(data.blockType).toBe('block');
       expect(data.filters[0]?.blockType).toBe('default');
+    });
+
+    it('defaults the expand block page details setting to false', async () => {
+      getChromeMock().storage.sync._data.set(STORAGE_KEY, {
+        groups: [createDefaultGroup()],
+        filters: [],
+      });
+
+      const data = await loadData();
+      expect(data.expandBlockPageDetails).toBe(false);
+    });
+
+    it('coerces invalid expand block page details values to false', () => {
+      const data = normalizeStoredData({
+        groups: [createDefaultGroup()],
+        filters: [],
+        whitelist: [],
+        expandBlockPageDetails: 'yes' as unknown as boolean,
+      });
+
+      expect(data.expandBlockPageDetails).toBe(false);
     });
   });
 

--- a/test/unit/shared/storageImportExport.test.ts
+++ b/test/unit/shared/storageImportExport.test.ts
@@ -53,6 +53,7 @@ function createSampleData(): StorageData {
     ],
     snooze: { active: true, until: 1_234_567_890 },
     blockType: 'block',
+    expandBlockPageDetails: false,
     rulesVersion: 4,
   };
 }
@@ -124,6 +125,30 @@ describe('storage import/export', () => {
 
   it('rejects invalid json imports', () => {
     expect(() => parseImportedData('{')).toThrow('Settings file is not valid JSON.');
+  });
+
+  it('rejects imports with an invalid expand block page details preference', () => {
+    expect(() =>
+      parseImportedData(
+        JSON.stringify({
+          groups: [createDefaultGroup()],
+          filters: [],
+          whitelist: [],
+          expandBlockPageDetails: 'yes',
+        })
+      )
+    ).toThrow('Settings file contains an invalid block page details preference.');
+  });
+
+  it('preserves the expand block page details preference on import', () => {
+    const parsed = parseImportedData(
+      JSON.stringify({
+        ...createSampleData(),
+        expandBlockPageDetails: true,
+      })
+    );
+
+    expect(parsed.expandBlockPageDetails).toBe(true);
   });
 
   it('rejects imports with duplicate ids', () => {


### PR DESCRIPTION
Makes the block page less distracting by collapsing everything except the icon, title, and description behind an understated **Learn more** link:

- The blocked URL, responsible-filter details, and all action buttons (Continue / Go Back / Manage Filters) now live in a hidden `#block-extras` container revealed by clicking **Learn more**. The link uses `aria-expanded`/`aria-controls` and disappears once expanded; the expansion persists across storage-change re-renders.
- New global setting `expandBlockPageDetails` (default off) with an **Expand block page details by default** checkbox in Global Settings, wired through the storage schema, defaults, normalization, and import/export validation. The block page (including the preview from Global Settings) reads it via `loadData()`.
- Block page button listeners are now attached before the first render so a fast click cannot be lost.

<img width="901" height="803" alt="image" src="https://github.com/user-attachments/assets/016d86d8-53ea-4ad6-8f5a-1b15e0a32346" />

<img width="966" height="993" alt="image" src="https://github.com/user-attachments/assets/47cea3f1-38eb-4b47-8e09-e3aed004e805" />

<img width="1201" height="424" alt="image" src="https://github.com/user-attachments/assets/55975156-5e49-4aee-9d22-e24fda49afbd" />
