### PR TITLE
Remove block types and make every block bypassable via Continue

### DIFF
--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -1,21 +1,20 @@
 import {
   clearBlockedTabState,
-  clearWarningBypassState,
+  clearBypassState,
   getBlockedPageState,
   getBlockedTabState,
+  getBypassState,
   getLastAllowedUrl,
-  getWarningBypassState,
   setBlockedPageState,
   setBlockedTabState,
+  setBypassState,
   setLastAllowedUrl,
-  setWarningBypassState,
 } from '../shared/api/session';
 import { getActiveTab, queryTabs, updateTabUrl } from '../shared/api/tabs';
 import { getExtensionUrl } from '../shared/api/runtime';
 import { PAGES } from '../shared/constants';
 import type { FilterDecision } from '../shared/filtering/engine';
 import {
-  type BlockType,
   type BlockedPageState,
   STORAGE_KEY,
   type BlockedTabState,
@@ -77,11 +76,8 @@ class TabController {
     const decision = rules.engine.evaluate(url);
 
     if (decision.action === 'block') {
-      if (
-        decision.blockType === 'warning' &&
-        (await this.isWarningBypassed(tabId, url, decision))
-      ) {
-        await this.allowTab(tabId, url, { preserveWarningBypass: true });
+      if (await this.isBypassed(tabId, url, decision)) {
+        await this.allowTab(tabId, url, { preserveBypass: true });
         return;
       }
 
@@ -107,15 +103,14 @@ class TabController {
     const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
     const bypassed =
       decision.action === 'block' &&
-      decision.blockType === 'warning' &&
-      (await this.isWarningBypassed(tabId, resolvedTarget.targetUrl, decision));
+      (await this.isBypassed(tabId, resolvedTarget.targetUrl, decision));
     if (decision.action === 'block' && !bypassed) {
       await this.ensureBlockedState(tabId, resolvedTarget.targetUrl, decision, rules.data);
       return false;
     }
 
     await updateTabUrl(tabId, resolvedTarget.targetUrl);
-    await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveWarningBypass: bypassed });
+    await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveBypass: bypassed });
     return true;
   }
 
@@ -248,14 +243,14 @@ class TabController {
     const targetTabId = resolvedTarget.tabId ?? tabId;
     const rules = await this.getRules();
     const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
-    if (decision.action !== 'block' || decision.blockType !== 'warning') {
+    if (decision.action !== 'block') {
       return false;
     }
 
     await Promise.all([
-      setWarningBypassState(targetTabId, {
+      setBypassState(targetTabId, {
         filterId: decision.filterId,
-        urlKey: getWarningBypassUrlKey(resolvedTarget.targetUrl),
+        urlKey: getBypassUrlKey(resolvedTarget.targetUrl),
       }),
       clearBlockedTabState(targetTabId),
       setLastAllowedUrl(targetTabId, resolvedTarget.targetUrl),
@@ -288,12 +283,11 @@ class TabController {
     const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
     const bypassed =
       decision.action === 'block' &&
-      decision.blockType === 'warning' &&
-      (await this.isWarningBypassed(tabId, resolvedTarget.targetUrl, decision));
+      (await this.isBypassed(tabId, resolvedTarget.targetUrl, decision));
     if (decision.action !== 'block' || bypassed) {
       if (resolvedTarget.hasSessionState) {
         await updateTabUrl(tabId, resolvedTarget.targetUrl);
-        await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveWarningBypass: bypassed });
+        await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveBypass: bypassed });
       }
       return;
     }
@@ -322,17 +316,17 @@ class TabController {
   private async allowTab(
     tabId: number,
     url: string,
-    options?: { readonly preserveWarningBypass?: boolean }
+    options?: { readonly preserveBypass?: boolean }
   ): Promise<void> {
     const operations: Promise<void>[] = [
       clearBlockedTabState(tabId),
       setLastAllowedUrl(tabId, url),
     ];
 
-    if (!options?.preserveWarningBypass) {
-      const warningBypass = await getWarningBypassState(tabId);
-      if (warningBypass && warningBypass.urlKey !== getWarningBypassUrlKey(url)) {
-        operations.push(clearWarningBypassState(tabId));
+    if (!options?.preserveBypass) {
+      const bypass = await getBypassState(tabId);
+      if (bypass && bypass.urlKey !== getBypassUrlKey(url)) {
+        operations.push(clearBypassState(tabId));
       }
     }
 
@@ -345,13 +339,11 @@ class TabController {
     decision: Extract<FilterDecision, { action: 'block' }>,
     data: StorageData
   ): Promise<BlockedStateResult> {
-    const blockType = getDecisionBlockType(decision);
     const blockId = createBlockId();
     const tabState: BlockedTabState = {
       blockId,
       tabId,
       targetUrl,
-      blockType,
       blockedAt: Date.now(),
       rulesVersion: data.rulesVersion,
       blockedBy: {
@@ -411,11 +403,7 @@ class TabController {
   ): Promise<BlockedStateResult | undefined> {
     const rules = currentRules ?? (await this.getRules());
     const decision = rules.engine.evaluate(targetUrl);
-    if (
-      decision.action !== 'block' ||
-      (decision.blockType === 'warning' &&
-        (await this.isWarningBypassed(tabId, targetUrl, decision)))
-    ) {
+    if (decision.action !== 'block' || (await this.isBypassed(tabId, targetUrl, decision))) {
       await clearBlockedTabState(tabId);
       return undefined;
     }
@@ -458,20 +446,13 @@ class TabController {
     return this.rulesProvider.loadCurrentRules();
   }
 
-  private async isWarningBypassed(
+  private async isBypassed(
     tabId: number,
     targetUrl: string,
     decision: Extract<FilterDecision, { action: 'block' }>
   ): Promise<boolean> {
-    if (decision.blockType !== 'warning') {
-      return false;
-    }
-
-    const warningBypass = await getWarningBypassState(tabId);
-    return (
-      warningBypass?.filterId === decision.filterId &&
-      warningBypass.urlKey === getWarningBypassUrlKey(targetUrl)
-    );
+    const bypass = await getBypassState(tabId);
+    return bypass?.filterId === decision.filterId && bypass.urlKey === getBypassUrlKey(targetUrl);
   }
 }
 
@@ -505,15 +486,6 @@ function createBlockId(): string {
   );
 }
 
-function getDecisionBlockType(decision: Extract<FilterDecision, { action: 'block' }>): BlockType {
-  const candidate = (decision as { readonly blockType?: unknown }).blockType;
-  return isBlockType(candidate) ? candidate : 'block';
-}
-
-function isBlockType(value: unknown): value is BlockType {
-  return value === 'block' || value === 'warning';
-}
-
 function isSameBlockedState(
   state: BlockedTabState,
   targetUrl: string,
@@ -524,12 +496,11 @@ function isSameBlockedState(
     state.targetUrl === targetUrl &&
     state.rulesVersion === rulesVersion &&
     state.blockedBy.filterId === decision.filterId &&
-    state.blockedBy.groupId === decision.groupId &&
-    state.blockType === getDecisionBlockType(decision)
+    state.blockedBy.groupId === decision.groupId
   );
 }
 
-function getWarningBypassUrlKey(targetUrl: string): string {
+function getBypassUrlKey(targetUrl: string): string {
   try {
     const parsed = new URL(targetUrl);
     return parsed.origin !== 'null' ? parsed.origin : targetUrl;

--- a/src/entrypoints/blocked/index.ts
+++ b/src/entrypoints/blocked/index.ts
@@ -9,7 +9,6 @@ import { loadData } from '../../shared/api/storage';
 import {
   MessageType,
   type BlockedPageState,
-  type BlockType,
   type FilterMatchMode,
   type GetBlockedPageStateResponse,
 } from '../../shared/types';
@@ -38,7 +37,7 @@ async function init(): Promise<void> {
   const continueButton = getElementByIdOrNull('continue');
   continueButton?.addEventListener('click', () => {
     void handleContinue().catch((error: unknown) => {
-      console.error('Failed to continue past warning:', error);
+      console.error('Failed to continue past block:', error);
     });
   });
 
@@ -110,9 +109,8 @@ function setExtrasExpanded(expanded: boolean): void {
 }
 
 async function getBlockedPageState(): Promise<BlockedPageViewModel> {
-  const previewBlockType = getPreviewBlockType();
-  if (previewBlockType) {
-    return getSampleBlockedPageState(previewBlockType);
+  if (isPreviewMode()) {
+    return getSampleBlockedPageState();
   }
 
   try {
@@ -163,25 +161,17 @@ function getUnavailableBlockedPageState(): BlockedPageViewModel {
 }
 
 /**
- * Read the sample block type requested via the `preview` query param.
- * Returns null when the page is showing a real block rather than a preview.
+ * Whether the page was opened as a preview via the `preview` query param rather than a real block.
  */
-function getPreviewBlockType(): BlockType | null {
-  const preview = new URLSearchParams(window.location.search).get('preview');
-  if (preview === 'warning') {
-    return 'warning';
-  }
-  if (preview === 'block') {
-    return 'block';
-  }
-  return null;
+function isPreviewMode(): boolean {
+  return new URLSearchParams(window.location.search).get('preview') !== null;
 }
 
 /**
  * Build a representative sample block so users can preview the page from the options screen
  * without needing to actually trigger a block.
  */
-function getSampleBlockedPageState(blockType: BlockType): BlockedPageViewModel {
+function getSampleBlockedPageState(): BlockedPageViewModel {
   const targetUrl = 'https://www.example.com/';
   return {
     targetUrl,
@@ -190,7 +180,6 @@ function getSampleBlockedPageState(blockType: BlockType): BlockedPageViewModel {
       tabId: -1,
       targetUrl,
       blockedBy: { filterId: 'preview-filter', groupId: 'preview-group' },
-      blockType,
       blockedAt: 0,
       rulesVersion: 0,
       filter: {
@@ -263,7 +252,7 @@ async function handleContinue(): Promise<void> {
   });
 
   if (!response.continued) {
-    console.warn('[Teichos] No warning bypass is available for this tab.');
+    console.warn('[Teichos] No bypass is available for this tab.');
   }
 }
 
@@ -300,7 +289,7 @@ function renderResponsibleFilter(state: BlockedPageViewModel): void {
 function renderActions(state: BlockedPageViewModel): void {
   const continueButton = getElementByIdOrNull<HTMLButtonElement>('continue');
   if (continueButton) {
-    continueButton.hidden = state.state?.blockType !== 'warning';
+    continueButton.hidden = !state.state;
   }
 }
 

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -135,16 +135,9 @@
         <div class="group-content">
           <div class="global-settings-panel">
             <p class="global-settings-note">
-              Choose the default block behavior for new and inherited filters, or export/import your
-              current Teichos configuration.
+              Adjust extension-wide preferences, or export/import your current Teichos
+              configuration.
             </p>
-            <div class="form-row">
-              <label for="global-block-type">Block Type</label>
-              <select id="global-block-type" class="input">
-                <option value="block">Block Page</option>
-                <option value="warning">Warning</option>
-              </select>
-            </div>
             <div class="form-row">
               <label class="checkbox-label">
                 <input type="checkbox" id="global-expand-details" />
@@ -393,14 +386,6 @@
               <option value="contains" selected>Contains (default)</option>
               <option value="exact">Exact</option>
               <option value="regex">Regular Expression</option>
-            </select>
-          </div>
-          <div class="form-row">
-            <label for="filter-block-type">Block Type</label>
-            <select id="filter-block-type" class="input">
-              <option value="default" selected>Default</option>
-              <option value="block">Block Page</option>
-              <option value="warning">Warning</option>
             </select>
           </div>
           <div class="form-row">

--- a/src/entrypoints/options/index.ts
+++ b/src/entrypoints/options/index.ts
@@ -19,9 +19,7 @@ import {
   deleteWhitelist,
 } from '../../shared/api/storage';
 import type {
-  BlockType,
   Filter,
-  FilterBlockType,
   FilterGroup,
   FilterMatchMode,
   StorageData,
@@ -103,9 +101,6 @@ function setupEventListeners(): void {
       void handleImportSettings(event);
     }
   );
-  getElementByIdOrNull<HTMLSelectElement>('global-block-type')?.addEventListener('change', () => {
-    void handleGlobalBlockTypeChange();
-  });
   getElementByIdOrNull<HTMLInputElement>('global-expand-details')?.addEventListener(
     'change',
     () => {
@@ -316,12 +311,11 @@ async function handleImportSettings(event: Event): Promise<void> {
 
 /**
  * Open the block page in a new tab using representative sample data so users can preview how a
- * block looks with the currently selected global block type.
+ * block looks without needing to actually trigger one.
  */
 async function handlePreviewBlockPage(): Promise<void> {
-  const blockType = getGlobalBlockTypeSelectValue();
   const url = new URL(getExtensionUrl(PAGES.BLOCKED));
-  url.searchParams.set('preview', blockType);
+  url.searchParams.set('preview', '1');
 
   try {
     await createTab({ url: url.toString(), active: true });
@@ -332,28 +326,9 @@ async function handlePreviewBlockPage(): Promise<void> {
 }
 
 function renderGlobalSettings(data: StorageData): void {
-  const blockTypeSelect = getElementByIdOrNull<HTMLSelectElement>('global-block-type');
-  if (blockTypeSelect) {
-    blockTypeSelect.value = data.blockType === 'warning' ? 'warning' : 'block';
-  }
-
   const expandDetailsCheckbox = getElementByIdOrNull<HTMLInputElement>('global-expand-details');
   if (expandDetailsCheckbox) {
     expandDetailsCheckbox.checked = data.expandBlockPageDetails === true;
-  }
-}
-
-async function handleGlobalBlockTypeChange(): Promise<void> {
-  const blockType = getGlobalBlockTypeSelectValue();
-
-  try {
-    const data = await loadData();
-    await saveData({ ...data, blockType });
-    setGlobalSettingsStatus('Block type updated.');
-  } catch (error) {
-    console.error('Failed to update global block type:', error);
-    setGlobalSettingsStatus('Failed to update block type.', true);
-    renderGlobalSettings(await loadData());
   }
 }
 
@@ -681,20 +656,6 @@ function getMatchModeSelectValue(selectId: string): FilterMatchMode {
   return 'contains';
 }
 
-function getGlobalBlockTypeSelectValue(): BlockType {
-  return getElementByIdOrNull<HTMLSelectElement>('global-block-type')?.value === 'warning'
-    ? 'warning'
-    : 'block';
-}
-
-function getFilterBlockTypeSelectValue(selectId: string): FilterBlockType {
-  const value = getElementByIdOrNull<HTMLSelectElement>(selectId)?.value;
-  if (value === 'block' || value === 'warning' || value === 'default') {
-    return value;
-  }
-  return 'default';
-}
-
 function ensureValidRegex(pattern: string, matchMode: FilterMatchMode): boolean {
   if (matchMode !== 'regex') {
     return true;
@@ -850,13 +811,11 @@ function openFilterModal(filterId?: string, groupId?: string): void {
         const descInput = getElementByIdOrNull<HTMLInputElement>('filter-description');
         const enabledInput = getElementByIdOrNull<HTMLInputElement>('filter-enabled');
         const matchModeSelect = getElementByIdOrNull<HTMLSelectElement>('filter-match-mode');
-        const blockTypeSelect = getElementByIdOrNull<HTMLSelectElement>('filter-block-type');
 
         if (patternInput) patternInput.value = filter.pattern;
         if (descInput) descInput.value = filter.description ?? '';
         if (enabledInput) enabledInput.checked = filter.enabled;
         if (matchModeSelect) matchModeSelect.value = filter.matchMode ?? 'contains';
-        if (blockTypeSelect) blockTypeSelect.value = filter.blockType ?? 'default';
       }
     })
     .catch((error: unknown) => {
@@ -885,7 +844,6 @@ async function handleFilterSubmit(e: Event): Promise<void> {
   const groupId = currentFilterGroupId ?? DEFAULT_GROUP_ID;
   const enabled = getElementByIdOrNull<HTMLInputElement>('filter-enabled')?.checked ?? true;
   const matchMode = getMatchModeSelectValue('filter-match-mode');
-  const blockType = getFilterBlockTypeSelectValue('filter-block-type');
 
   if (!ensureValidRegex(pattern, matchMode)) {
     return;
@@ -904,7 +862,6 @@ async function handleFilterSubmit(e: Event): Promise<void> {
     groupId,
     enabled,
     matchMode,
-    blockType,
   };
   const filter: Filter = typeof expiresAt === 'number' ? { ...baseFilter, expiresAt } : baseFilter;
 

--- a/src/shared/api/session.ts
+++ b/src/shared/api/session.ts
@@ -3,23 +3,22 @@
  */
 
 import type {
-  BlockType,
   BlockedEffectiveState,
   BlockedFilterSnapshot,
   BlockedGroupSnapshot,
   BlockedPageState,
   BlockedTabState,
+  BypassState,
   FilterMatchMode,
   SnoozeState,
   TimeSchedule,
-  WarningBypassState,
 } from '../types';
 
 const LAST_ALLOWED_URL_KEY_PREFIX = 'last_allowed_url_' as const;
 const SNOOZE_OVERRIDE_KEY = 'snooze_override' as const;
 const BLOCKED_TAB_STATE_KEY_PREFIX = 'blocked_tab_state_' as const;
 const BLOCKED_PAGE_STATE_KEY_PREFIX = 'blocked_page_state_' as const;
-const WARNING_BYPASS_KEY_PREFIX = 'warning_bypass_' as const;
+const BYPASS_KEY_PREFIX = 'bypass_' as const;
 
 function lastAllowedUrlKey(tabId: number): string {
   return `${LAST_ALLOWED_URL_KEY_PREFIX}${tabId}`;
@@ -33,8 +32,8 @@ function blockedPageStateKey(blockId: string): string {
   return `${BLOCKED_PAGE_STATE_KEY_PREFIX}${blockId}`;
 }
 
-function warningBypassKey(tabId: number): string {
-  return `${WARNING_BYPASS_KEY_PREFIX}${tabId}`;
+function bypassKey(tabId: number): string {
+  return `${BYPASS_KEY_PREFIX}${tabId}`;
 }
 
 /**
@@ -64,7 +63,6 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
     typeof candidate.blockId !== 'string' ||
     typeof candidate.tabId !== 'number' ||
     typeof candidate.targetUrl !== 'string' ||
-    !isBlockType(candidate.blockType) ||
     typeof candidate.blockedAt !== 'number' ||
     typeof candidate.rulesVersion !== 'number' ||
     !candidate.blockedBy ||
@@ -78,7 +76,6 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
     blockId: candidate.blockId,
     tabId: candidate.tabId,
     targetUrl: candidate.targetUrl,
-    blockType: candidate.blockType,
     blockedAt: candidate.blockedAt,
     rulesVersion: candidate.rulesVersion,
     blockedBy: {
@@ -102,12 +99,12 @@ export async function clearBlockedTabState(tabId: number): Promise<void> {
   await chrome.storage.session.remove(blockedTabStateKey(tabId));
 }
 
-function normalizeWarningBypassState(value: unknown): WarningBypassState | undefined {
+function normalizeBypassState(value: unknown): BypassState | undefined {
   if (!value || typeof value !== 'object') {
     return undefined;
   }
 
-  const candidate = value as Partial<WarningBypassState>;
+  const candidate = value as Partial<BypassState>;
   if (typeof candidate.filterId !== 'string' || typeof candidate.urlKey !== 'string') {
     return undefined;
   }
@@ -118,27 +115,18 @@ function normalizeWarningBypassState(value: unknown): WarningBypassState | undef
   };
 }
 
-export async function setWarningBypassState(
-  tabId: number,
-  state: WarningBypassState
-): Promise<void> {
-  await chrome.storage.session.set({ [warningBypassKey(tabId)]: state });
+export async function setBypassState(tabId: number, state: BypassState): Promise<void> {
+  await chrome.storage.session.set({ [bypassKey(tabId)]: state });
 }
 
-export async function getWarningBypassState(
-  tabId: number
-): Promise<WarningBypassState | undefined> {
-  const key = warningBypassKey(tabId);
+export async function getBypassState(tabId: number): Promise<BypassState | undefined> {
+  const key = bypassKey(tabId);
   const result = await chrome.storage.session.get(key);
-  return normalizeWarningBypassState(result[key]);
+  return normalizeBypassState(result[key]);
 }
 
-export async function clearWarningBypassState(tabId: number): Promise<void> {
-  await chrome.storage.session.remove(warningBypassKey(tabId));
-}
-
-function isBlockType(value: unknown): value is BlockType {
-  return value === 'block' || value === 'warning';
+export async function clearBypassState(tabId: number): Promise<void> {
+  await chrome.storage.session.remove(bypassKey(tabId));
 }
 
 function isFilterMatchMode(value: unknown): value is FilterMatchMode {

--- a/src/shared/filtering/engine.ts
+++ b/src/shared/filtering/engine.ts
@@ -1,4 +1,4 @@
-import type { BlockType, Filter, FilterGroup, StorageData, Whitelist } from '../types';
+import type { Filter, FilterGroup, StorageData, Whitelist } from '../types';
 import { matchesPattern } from './patterns';
 import {
   buildGroupById,
@@ -26,7 +26,6 @@ export type FilterDecision =
       readonly action: 'block';
       readonly filterId: string;
       readonly groupId: string;
-      readonly blockType: BlockType;
       readonly reason: 'matched-filter';
     };
 
@@ -89,7 +88,6 @@ export function evaluateFilterDecision(
   const urlLower = url.toLowerCase();
   const now = Date.now();
   let fallbackReason: FilterDecisionAllowReason = 'no-match';
-  let warningDecision: Extract<FilterDecision, { action: 'block' }> | undefined;
 
   for (const filter of filters) {
     if (!matchesPattern(url, filter, undefined, urlLower)) {
@@ -119,35 +117,15 @@ export function evaluateFilterDecision(
       }
     }
 
-    const blockType = resolveFilterBlockType(filter, data);
-    const decision: Extract<FilterDecision, { action: 'block' }> = {
+    return {
       action: 'block',
       filterId: filter.id,
       groupId: filter.groupId,
-      blockType,
       reason: 'matched-filter',
     };
-
-    if (blockType === 'block') {
-      return decision;
-    }
-
-    warningDecision ??= decision;
-  }
-
-  if (warningDecision) {
-    return warningDecision;
   }
 
   return { action: 'allow', reason: fallbackReason };
-}
-
-function resolveFilterBlockType(filter: Filter, data: StorageData): BlockType {
-  if (filter.blockType === 'block' || filter.blockType === 'warning') {
-    return filter.blockType;
-  }
-
-  return data.blockType === 'warning' ? 'warning' : 'block';
 }
 
 function selectHigherPriorityReason(

--- a/src/shared/storage/defaults.ts
+++ b/src/shared/storage/defaults.ts
@@ -17,7 +17,6 @@ export function createDefaultData(): StorageData {
     filters: [],
     whitelist: [],
     snooze: { active: false },
-    blockType: 'block',
     expandBlockPageDetails: false,
     rulesVersion: 0,
   };

--- a/src/shared/storage/guards.ts
+++ b/src/shared/storage/guards.ts
@@ -1,7 +1,5 @@
 import type {
-  BlockType,
   Filter,
-  FilterBlockType,
   FilterGroup,
   FilterMatchMode,
   SnoozeState,
@@ -13,7 +11,7 @@ export type JsonObject = Record<string, unknown>;
 
 export interface FilterLike extends Omit<Filter, 'matchMode'> {
   readonly matchMode?: FilterMatchMode;
-  readonly blockType?: FilterBlockType;
+  readonly blockType?: string;
   readonly isRegex?: boolean;
 }
 
@@ -34,14 +32,6 @@ export function isObject(value: unknown): value is JsonObject {
 
 export function isValidMatchMode(value: unknown): value is FilterMatchMode {
   return value === 'contains' || value === 'exact' || value === 'regex';
-}
-
-export function isValidBlockType(value: unknown): value is BlockType {
-  return value === 'block' || value === 'warning';
-}
-
-export function isValidFilterBlockType(value: unknown): value is FilterBlockType {
-  return value === 'default' || isValidBlockType(value);
 }
 
 function isOptionalString(value: unknown): value is string | undefined {
@@ -99,7 +89,7 @@ export function isValidFilterLike(value: unknown): value is FilterLike {
     typeof value['groupId'] === 'string' &&
     typeof value['enabled'] === 'boolean' &&
     (value['matchMode'] === undefined || isValidMatchMode(value['matchMode'])) &&
-    (value['blockType'] === undefined || isValidFilterBlockType(value['blockType'])) &&
+    isOptionalString(value['blockType']) &&
     isOptionalBoolean(value['isRegex']) &&
     isOptionalString(value['description']) &&
     isOptionalFiniteNumber(value['expiresAt'])

--- a/src/shared/storage/importExport.ts
+++ b/src/shared/storage/importExport.ts
@@ -3,7 +3,6 @@ import { DEFAULT_GROUP_ID } from '../types';
 import { getRegexValidationError } from '../filtering/patterns';
 import {
   isObject,
-  isValidBlockType,
   isValidFilterLike,
   isValidGroup,
   isValidSnooze,
@@ -117,10 +116,6 @@ function validateImportedStorageShape(raw: JsonObject): void {
 
   if (!isOptionalFiniteNumber(raw['rulesVersion'])) {
     throw new Error('Settings file contains an invalid rules version.');
-  }
-
-  if (raw['blockType'] !== undefined && !isValidBlockType(raw['blockType'])) {
-    throw new Error('Settings file contains an invalid block type.');
   }
 
   if (

--- a/src/shared/storage/normalize.ts
+++ b/src/shared/storage/normalize.ts
@@ -1,7 +1,5 @@
 import type {
-  BlockType,
   Filter,
-  FilterBlockType,
   FilterGroup,
   FilterMatchMode,
   SnoozeState,
@@ -10,11 +8,10 @@ import type {
 } from '../types';
 import { DEFAULT_GROUP_ID } from '../types';
 import { createDefaultData, createDefaultGroup } from './defaults';
-import { isValidBlockType, isValidFilterBlockType } from './guards';
 
 export type LegacyFilter = Omit<Filter, 'matchMode'> & {
   readonly matchMode?: FilterMatchMode;
-  readonly blockType?: FilterBlockType;
+  readonly blockType?: string;
   readonly isRegex?: boolean;
 };
 
@@ -29,7 +26,7 @@ export interface LegacyStorageData {
   readonly filters?: readonly LegacyFilter[];
   readonly whitelist?: readonly LegacyWhitelist[];
   readonly rulesVersion?: number;
-  readonly blockType?: BlockType;
+  readonly blockType?: string;
   readonly expandBlockPageDetails?: boolean;
   readonly snooze?: {
     readonly active?: boolean;
@@ -48,10 +45,10 @@ function resolveMatchMode(
 }
 
 function normalizeFilters(filters: readonly LegacyFilter[] | undefined): Filter[] {
-  return (filters ?? []).map(({ isRegex, matchMode, blockType, ...filter }) => ({
+  // blockType is a retired per-filter setting; strip it from legacy data.
+  return (filters ?? []).map(({ isRegex, matchMode, blockType: _blockType, ...filter }) => ({
     ...filter,
     matchMode: resolveMatchMode(matchMode, isRegex),
-    blockType: isValidFilterBlockType(blockType) ? blockType : 'default',
   }));
 }
 
@@ -99,7 +96,6 @@ export function normalizeStoredData(raw: LegacyStorageData | undefined): Storage
     typeof raw.rulesVersion === 'number' && Number.isFinite(raw.rulesVersion)
       ? raw.rulesVersion
       : 0;
-  const blockType = isValidBlockType(raw.blockType) ? raw.blockType : 'block';
   const expandBlockPageDetails = raw.expandBlockPageDetails === true;
 
   return {
@@ -107,7 +103,6 @@ export function normalizeStoredData(raw: LegacyStorageData | undefined): Storage
     filters,
     whitelist,
     snooze,
-    blockType,
     expandBlockPageDetails,
     rulesVersion,
   };

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -29,9 +29,6 @@ export interface FilterGroup {
 /** URL matching modes for filters and whitelist entries */
 export type FilterMatchMode = 'contains' | 'exact' | 'regex';
 
-export type BlockType = 'block' | 'warning';
-export type FilterBlockType = 'default' | BlockType;
-
 /** URL filter pattern */
 export interface Filter {
   readonly id: string;
@@ -39,7 +36,6 @@ export interface Filter {
   readonly groupId: string;
   readonly enabled: boolean;
   readonly matchMode: FilterMatchMode;
-  readonly blockType?: FilterBlockType;
   readonly description?: string;
   readonly expiresAt?: number; // Epoch ms when a temporary filter expires
 }
@@ -70,7 +66,6 @@ export interface BlockedTabState {
   readonly tabId: number;
   readonly targetUrl: string;
   readonly blockedBy: BlockedBy;
-  readonly blockType: BlockType;
   readonly blockedAt: number;
   readonly rulesVersion: number;
 }
@@ -96,7 +91,8 @@ export interface BlockedPageState extends BlockedTabState {
   readonly effectiveState: BlockedEffectiveState;
 }
 
-export interface WarningBypassState {
+/** Per-tab record of a block the user chose to continue past. */
+export interface BypassState {
   readonly filterId: string;
   readonly urlKey: string;
 }
@@ -107,7 +103,6 @@ export interface StorageData {
   readonly filters: readonly Filter[];
   readonly whitelist: readonly Whitelist[];
   readonly snooze: SnoozeState;
-  readonly blockType?: BlockType;
   readonly expandBlockPageDetails?: boolean;
   readonly rulesVersion: number;
 }

--- a/test/e2e/blocked.spec.ts
+++ b/test/e2e/blocked.spec.ts
@@ -103,23 +103,22 @@ test('renders the blocked url and responsible filter from block id state', async
   await expect(page.getByLabel('Responsible filter')).toContainText('blocked-state.example.test');
 });
 
-test('warning blocks show Continue and allow same-tab bypass', async ({ extensionPage, page }) => {
-  const targetUrl = 'https://warning-bypass.example.test/warning-focus';
-  await mockAllowedPage(page, targetUrl, 'Warning bypass allowed');
+test('blocked pages show Continue and allow same-tab bypass', async ({ extensionPage, page }) => {
+  const targetUrl = 'https://bypass.example.test/bypass-focus';
+  await mockAllowedPage(page, targetUrl, 'Bypass allowed');
 
   await page.goto(extensionPage(PAGES.OPTIONS));
   await seedStorage(
     page,
     createStorageData({
-      blockType: 'warning',
       filters: [
         {
-          id: 'warning-filter',
-          pattern: 'warning-bypass.example.test/warning',
+          id: 'bypass-filter',
+          pattern: 'bypass.example.test/bypass',
           groupId: defaultGroup.id,
           enabled: true,
           matchMode: 'contains',
-          description: 'Warning Filter',
+          description: 'Bypass Filter',
         },
       ],
     })
@@ -134,19 +133,14 @@ test('warning blocks show Continue and allow same-tab bypass', async ({ extensio
   await expectAllowed(page, targetUrl);
 });
 
-test('renders a sample block for each preview block type', async ({ extensionPage, page }) => {
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
+test('renders a sample block in preview mode', async ({ extensionPage, page }) => {
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=1`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toHaveText('https://www.example.com/');
   await showBlockPageDetails(page);
   await expect(page.getByLabel('Responsible filter')).toContainText('Example filter');
   await expect(page.getByLabel('Responsible filter')).toContainText('example.com');
   await expect(page.getByLabel('Responsible filter')).toContainText('Example group');
-  await expect(page.locator('#continue')).toBeHidden();
-
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=warning`);
-  await expect(page.getByLabel('Blocked URL')).toHaveText('https://www.example.com/');
-  await showBlockPageDetails(page);
   await expect(page.locator('#continue')).toBeVisible();
 });
 
@@ -154,7 +148,7 @@ test('hides details and actions behind the Learn more link by default', async ({
   extensionPage,
   page,
 }) => {
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=1`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
 
   const learnMore = page.getByRole('button', { name: 'Learn more' });
@@ -181,7 +175,7 @@ test('expands details by default when the global setting is enabled', async ({
   await page.locator('#global-expand-details').check();
   await expect.poll(async () => (await readStorage(page))?.expandBlockPageDetails).toBe(true);
 
-  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=block`);
+  await page.goto(`${extensionPage(PAGES.BLOCKED)}?preview=1`);
   await expect(page.getByRole('heading', { name: 'Page Blocked' })).toBeVisible();
   await expect(page.getByLabel('Blocked URL')).toBeVisible();
   await expect(page.getByLabel('Responsible filter')).toBeVisible();
@@ -196,7 +190,6 @@ test('previews the block page from the options global settings', async ({
 }) => {
   await page.goto(extensionPage(PAGES.OPTIONS));
   await waitForOptionsReady(page);
-  await page.locator('#global-block-type').selectOption('warning');
 
   const previewPagePromise = context.waitForEvent('page');
   await page.getByRole('button', { name: 'Preview Block Page' }).click();

--- a/test/e2e/helpers.ts
+++ b/test/e2e/helpers.ts
@@ -26,7 +26,6 @@ export function createStorageData(overrides: Partial<StorageData> = {}): Storage
     filters: overrides.filters ?? [],
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
-    blockType: overrides.blockType ?? 'block',
     expandBlockPageDetails: overrides.expandBlockPageDetails ?? false,
     rulesVersion: overrides.rulesVersion ?? 0,
   };
@@ -129,7 +128,6 @@ export async function createFilterViaOptions(
     name?: string;
     pattern: string;
     matchMode?: 'contains' | 'exact' | 'regex';
-    blockType?: 'default' | 'block' | 'warning';
     enabled?: boolean;
   }
 ): Promise<void> {
@@ -145,7 +143,6 @@ export async function createFilterViaOptions(
   await modal.locator('#filter-description').fill(filter.name ?? '');
   await modal.locator('#filter-pattern').fill(filter.pattern);
   await modal.locator('#filter-match-mode').selectOption(filter.matchMode ?? 'contains');
-  await modal.locator('#filter-block-type').selectOption(filter.blockType ?? 'default');
 
   const enabled = filter.enabled ?? true;
   const enabledInput = modal.getByLabel('Enabled');

--- a/test/e2e/options.spec.ts
+++ b/test/e2e/options.spec.ts
@@ -193,41 +193,6 @@ test('exports current settings from global settings', async ({ extensionPage, pa
   );
 });
 
-test('persists global and per-filter block types from the options UI', async ({
-  extensionPage,
-  page,
-}) => {
-  await gotoOptions(extensionPage, page);
-
-  await page.getByLabel('Block Type').first().selectOption('warning');
-  await expect(page.locator('#global-settings-status')).toHaveText('Block type updated.');
-
-  await createFilterViaOptions(page, {
-    name: 'Inherited Warning',
-    pattern: 'warning.example.test',
-    blockType: 'default',
-  });
-
-  const filterCard = page.locator('.filter-item').filter({ hasText: 'Inherited Warning' });
-  await filterCard.getByRole('button', { name: 'Edit' }).click();
-  const filterModal = page.locator('#filter-modal.active');
-  await expect(filterModal).toBeVisible();
-  await filterModal.locator('#filter-block-type').selectOption('block');
-  await filterModal.getByRole('button', { name: 'Save' }).click();
-
-  await expect
-    .poll(() => readStorage(page))
-    .toMatchObject({
-      blockType: 'warning',
-      filters: [
-        expect.objectContaining({
-          description: 'Inherited Warning',
-          blockType: 'block',
-        }),
-      ],
-    });
-});
-
 test('imports settings from global settings', async ({ extensionPage, page }) => {
   await gotoOptions(extensionPage, page);
   await seedStorage(

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -47,7 +47,6 @@ const defaultData = {
   filters: [],
   whitelist: [],
   snooze: { active: false },
-  blockType: 'block' as const,
   rulesVersion: 1,
 };
 
@@ -167,7 +166,6 @@ describe('handleMessage', () => {
       action: 'block',
       filterId: 'filter-1',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
     const sendResponse = vi.fn();
@@ -212,7 +210,6 @@ describe('handleMessage', () => {
       blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 2,
       blockedBy: {
@@ -290,7 +287,6 @@ describe('handleMessage', () => {
         blockId: 'block-8',
         tabId: 8,
         targetUrl: 'https://blocked.com/focus',
-        blockType: 'block',
         blockedAt: 1234,
         rulesVersion: 2,
         blockedBy: {

--- a/test/unit/background/rulesProvider.test.ts
+++ b/test/unit/background/rulesProvider.test.ts
@@ -12,7 +12,6 @@ function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
     filters: overrides.filters ?? [],
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
-    blockType: overrides.blockType ?? 'block',
     rulesVersion: overrides.rulesVersion ?? 0,
   };
 }
@@ -52,7 +51,6 @@ describe('RulesProvider', () => {
       action: 'block',
       filterId: 'filter-1',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
   });
@@ -156,21 +154,18 @@ describe('RulesProvider', () => {
       action: 'block',
       filterId: 'stale-filter',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
     expect(refreshedRules.engine.evaluate('https://fresh.example')).toEqual({
       action: 'block',
       filterId: 'fresh-filter',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
     expect(cachedRules.engine.evaluate('https://fresh.example')).toEqual({
       action: 'block',
       filterId: 'fresh-filter',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
     expect(cachedRules.engine.evaluate('https://stale.example')).toEqual({
@@ -210,7 +205,6 @@ describe('RulesProvider', () => {
       action: 'block',
       filterId: 'filter-2',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
   });
@@ -228,7 +222,6 @@ describe('RulesProvider', () => {
       filters: [],
       whitelist: [],
       snooze: { active: false },
-      blockType: 'block',
       expandBlockPageDetails: false,
       rulesVersion: 0,
     });

--- a/test/unit/background/snooze.test.ts
+++ b/test/unit/background/snooze.test.ts
@@ -23,7 +23,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: activeTimedSnooze,
-      blockType: 'block',
       rulesVersion: 1,
     });
 
@@ -51,7 +50,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: expired,
-      blockType: 'block',
     });
 
     const { registerSnoozeHandlers } = await import('../../../src/background/snooze');
@@ -65,7 +63,6 @@ describe('registerSnoozeHandlers', () => {
         filters: [],
         whitelist: [],
         snooze: { active: false },
-        blockType: 'block',
         expandBlockPageDetails: false,
         rulesVersion: 1,
       });
@@ -87,7 +84,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: activeTimedSnooze,
-      blockType: 'block',
       rulesVersion: 2,
     });
 
@@ -110,7 +106,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: { active: true, until: Date.now() - 1 },
-      blockType: 'block',
       rulesVersion: 1,
     });
 
@@ -124,7 +119,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: { active: true, until: Date.now() - 1 },
-      blockType: 'block',
       rulesVersion: 1,
     });
 
@@ -134,7 +128,6 @@ describe('registerSnoozeHandlers', () => {
       filters: [],
       whitelist: [],
       snooze: { active: true, until: Date.now() - 1 },
-      blockType: 'block',
       rulesVersion: 1,
     });
 
@@ -148,7 +141,6 @@ describe('registerSnoozeHandlers', () => {
         filters: [],
         whitelist: [],
         snooze: { active: false },
-        blockType: 'block',
         expandBlockPageDetails: false,
         rulesVersion: 2,
       });

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -18,7 +18,6 @@ function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
     filters: overrides.filters ?? [],
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
-    blockType: overrides.blockType ?? 'block',
     rulesVersion: overrides.rulesVersion ?? 1,
   };
 }
@@ -59,7 +58,6 @@ describe('TabController', () => {
       blockId: expect.any(String),
       tabId: 4,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 7,
       blockedBy: {
@@ -122,7 +120,6 @@ describe('TabController', () => {
       blockId: expect.any(String),
       tabId: 6,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 8,
       blockedBy: {
@@ -151,7 +148,6 @@ describe('TabController', () => {
       blockId: 'block-5',
       tabId: 5,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 3,
       blockedBy: {
@@ -196,7 +192,6 @@ describe('TabController', () => {
       blockId: 'stale-block',
       tabId: 7,
       targetUrl: 'https://stale-blocked.com/focus',
-      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 8,
       blockedBy: {
@@ -208,7 +203,6 @@ describe('TabController', () => {
       blockId: 'allowed-block',
       tabId: 7,
       targetUrl: 'https://allowed.com/focus',
-      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 8,
       blockedBy: {
@@ -267,7 +261,6 @@ describe('TabController', () => {
       blockId: 'stale-block',
       tabId: 10,
       targetUrl: 'https://stale-blocked.com/focus',
-      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 9,
       blockedBy: {
@@ -279,7 +272,6 @@ describe('TabController', () => {
       blockId: 'fresh-block',
       tabId: 10,
       targetUrl: 'https://fresh-blocked.com/focus',
-      blockType: 'block',
       blockedAt: Date.now(),
       rulesVersion: 9,
       blockedBy: {
@@ -310,7 +302,6 @@ describe('TabController', () => {
       blockId: expect.any(String),
       tabId: 10,
       targetUrl: 'https://fresh-blocked.com/focus',
-      blockType: 'block',
       blockedAt: expect.any(Number),
       rulesVersion: 10,
       blockedBy: {
@@ -320,52 +311,49 @@ describe('TabController', () => {
     });
   });
 
-  it('re-evaluates a blocked page as warning when rules change from hard block to warning', async () => {
+  it('re-evaluates a stale blocked page in place when rules change', async () => {
     const chromeMock = getChromeMock();
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
       createStorageData({
         filters: [
           {
-            id: 'warning-filter',
-            pattern: 'warning-blocked.com',
+            id: 'still-blocking-filter',
+            pattern: 'still-blocked.com',
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains',
           },
         ],
         rulesVersion: 11,
-        blockType: 'warning',
       })
     );
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
-      blockId: 'hard-block',
+      blockId: 'stale-block',
       tabId: 11,
-      targetUrl: 'https://warning-blocked.com/focus',
-      blockType: 'block',
+      targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
       rulesVersion: 10,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'still-blocking-filter',
         groupId: DEFAULT_GROUP_ID,
       },
     });
     await setBlockedPageState({
-      blockId: 'hard-block',
+      blockId: 'stale-block',
       tabId: 11,
-      targetUrl: 'https://warning-blocked.com/focus',
-      blockType: 'block',
+      targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
       rulesVersion: 10,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'still-blocking-filter',
         groupId: DEFAULT_GROUP_ID,
       },
       filter: {
-        id: 'warning-filter',
-        pattern: 'warning-blocked.com',
+        id: 'still-blocking-filter',
+        pattern: 'still-blocked.com',
         matchMode: 'contains',
       },
       group: {
@@ -382,35 +370,34 @@ describe('TabController', () => {
     });
 
     await expect(
-      getTabController().getFreshBlockedPageState(11, blockedPageUrl('hard-block'))
+      getTabController().getFreshBlockedPageState(11, blockedPageUrl('stale-block'))
     ).resolves.toEqual({
       status: 'blocked',
       state: expect.objectContaining({
-        targetUrl: 'https://warning-blocked.com/focus',
-        blockType: 'warning',
+        targetUrl: 'https://still-blocked.com/focus',
+        rulesVersion: 11,
         blockedBy: {
-          filterId: 'warning-filter',
+          filterId: 'still-blocking-filter',
           groupId: DEFAULT_GROUP_ID,
         },
       }),
     });
 
     const refreshedState = await getBlockedTabState(11);
-    expect(refreshedState?.blockType).toBe('warning');
-    expect(refreshedState?.blockId).not.toBe('hard-block');
+    expect(refreshedState?.rulesVersion).toBe(11);
+    expect(refreshedState?.blockId).not.toBe('stale-block');
     expect(chromeMock.tabs.update).not.toHaveBeenCalled();
   });
 
-  it('continues past warning blocks for the same tab and origin only', async () => {
+  it('continues past blocks for the same tab and origin only', async () => {
     const chromeMock = getChromeMock();
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
       createStorageData({
-        blockType: 'warning',
         filters: [
           {
-            id: 'warning-filter',
-            pattern: 'warning.com',
+            id: 'bypassed-filter',
+            pattern: 'bypass.com',
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains',
@@ -425,37 +412,35 @@ describe('TabController', () => {
           {
             id: 12,
             active: true,
-            url: blockedPageUrl('warning-block'),
+            url: blockedPageUrl('bypass-block'),
           } as chrome.tabs.Tab,
         ]);
       }
     );
     await setBlockedTabState({
-      blockId: 'warning-block',
+      blockId: 'bypass-block',
       tabId: 12,
-      targetUrl: 'https://warning.com/focus',
-      blockType: 'warning',
+      targetUrl: 'https://bypass.com/focus',
       blockedAt: Date.now(),
       rulesVersion: 12,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'bypassed-filter',
         groupId: DEFAULT_GROUP_ID,
       },
     });
     await setBlockedPageState({
-      blockId: 'warning-block',
+      blockId: 'bypass-block',
       tabId: 12,
-      targetUrl: 'https://warning.com/focus',
-      blockType: 'warning',
+      targetUrl: 'https://bypass.com/focus',
       blockedAt: Date.now(),
       rulesVersion: 12,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'bypassed-filter',
         groupId: DEFAULT_GROUP_ID,
       },
       filter: {
-        id: 'warning-filter',
-        pattern: 'warning.com',
+        id: 'bypassed-filter',
+        pattern: 'bypass.com',
         matchMode: 'contains',
       },
       group: {
@@ -476,16 +461,16 @@ describe('TabController', () => {
     await expect(getTabController().continueFromActiveTab()).resolves.toBe(true);
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       12,
-      { url: 'https://warning.com/focus' },
+      { url: 'https://bypass.com/focus' },
       expect.any(Function)
     );
 
     chromeMock.tabs.update.mockClear();
-    await getTabController().evaluateNavigation(12, 'https://warning.com/next');
+    await getTabController().evaluateNavigation(12, 'https://bypass.com/next');
     expect(chromeMock.tabs.update).not.toHaveBeenCalled();
 
     await getTabController().evaluateNavigation(12, 'https://elsewhere.com');
-    await getTabController().evaluateNavigation(12, 'https://warning.com/blocked-again');
+    await getTabController().evaluateNavigation(12, 'https://bypass.com/blocked-again');
     expect(chromeMock.tabs.update).toHaveBeenLastCalledWith(
       12,
       { url: expect.stringContaining(`/${PAGES.BLOCKED}?blockId=`) },
@@ -493,7 +478,7 @@ describe('TabController', () => {
     );
   });
 
-  it('lets hard blocks override an existing warning bypass', async () => {
+  it('re-blocks a bypassed tab when a different filter becomes responsible', async () => {
     const chromeMock = getChromeMock();
     chromeMock.tabs.query.mockImplementation(
       (_query, callback?: (tabs: chrome.tabs.Tab[]) => void) => {
@@ -501,7 +486,7 @@ describe('TabController', () => {
           {
             id: 14,
             active: true,
-            url: blockedPageUrl('warning-first'),
+            url: blockedPageUrl('bypass-first'),
           } as chrome.tabs.Tab,
         ]);
       }
@@ -509,10 +494,9 @@ describe('TabController', () => {
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
       createStorageData({
-        blockType: 'warning',
         filters: [
           {
-            id: 'warning-filter',
+            id: 'original-filter',
             pattern: 'override.com',
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
@@ -523,30 +507,28 @@ describe('TabController', () => {
       })
     );
     await setBlockedTabState({
-      blockId: 'warning-first',
+      blockId: 'bypass-first',
       tabId: 14,
       targetUrl: 'https://override.com/focus',
-      blockType: 'warning',
       blockedAt: Date.now(),
       rulesVersion: 13,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,
       },
     });
     await setBlockedPageState({
-      blockId: 'warning-first',
+      blockId: 'bypass-first',
       tabId: 14,
       targetUrl: 'https://override.com/focus',
-      blockType: 'warning',
       blockedAt: Date.now(),
       rulesVersion: 13,
       blockedBy: {
-        filterId: 'warning-filter',
+        filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,
       },
       filter: {
-        id: 'warning-filter',
+        id: 'original-filter',
         pattern: 'override.com',
         matchMode: 'contains',
       },
@@ -569,22 +551,20 @@ describe('TabController', () => {
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
       createStorageData({
-        blockType: 'warning',
         filters: [
           {
-            id: 'warning-filter',
+            id: 'original-filter',
             pattern: 'override.com',
             groupId: DEFAULT_GROUP_ID,
-            enabled: true,
+            enabled: false,
             matchMode: 'contains',
           },
           {
-            id: 'hard-filter',
+            id: 'replacement-filter',
             pattern: 'override.com',
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains',
-            blockType: 'block',
           },
         ],
         rulesVersion: 14,
@@ -600,8 +580,7 @@ describe('TabController', () => {
     );
 
     const state = await getBlockedTabState(14);
-    expect(state?.blockType).toBe('block');
-    expect(state?.blockedBy.filterId).toBe('hard-filter');
+    expect(state?.blockedBy.filterId).toBe('replacement-filter');
   });
 
   it('reconciles open tabs after storage changes', async () => {

--- a/test/unit/shared/filteringEngine.test.ts
+++ b/test/unit/shared/filteringEngine.test.ts
@@ -15,7 +15,6 @@ function createStorageData(overrides: Partial<StorageData> = {}): StorageData {
     filters: overrides.filters ?? [],
     whitelist: overrides.whitelist ?? [],
     snooze: overrides.snooze ?? { active: false },
-    blockType: overrides.blockType ?? 'block',
     rulesVersion: overrides.rulesVersion ?? 0,
   };
 }
@@ -112,7 +111,6 @@ describe('filteringEngine', () => {
       action: 'block',
       filterId: 'filter-1',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
   });
@@ -227,69 +225,6 @@ describe('filteringEngine', () => {
       action: 'block',
       filterId: 'active-filter',
       groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
-      reason: 'matched-filter',
-    });
-  });
-
-  it('inherits the global warning block type', () => {
-    const decision = evaluateFilterDecision(
-      'https://warning.example.test',
-      createStorageData({
-        blockType: 'warning',
-        filters: [
-          {
-            id: 'warning-filter',
-            pattern: 'warning.example.test',
-            groupId: DEFAULT_GROUP_ID,
-            enabled: true,
-            matchMode: 'contains',
-          },
-        ],
-      }),
-      { context: activeContext }
-    );
-
-    expect(decision).toEqual({
-      action: 'block',
-      filterId: 'warning-filter',
-      groupId: DEFAULT_GROUP_ID,
-      blockType: 'warning',
-      reason: 'matched-filter',
-    });
-  });
-
-  it('prefers a hard block over an earlier warning match', () => {
-    const decision = evaluateFilterDecision(
-      'https://mixed.example.test',
-      createStorageData({
-        blockType: 'warning',
-        filters: [
-          {
-            id: 'warning-filter',
-            pattern: 'mixed.example.test',
-            groupId: DEFAULT_GROUP_ID,
-            enabled: true,
-            matchMode: 'contains',
-          },
-          {
-            id: 'block-filter',
-            pattern: 'mixed.example.test',
-            groupId: DEFAULT_GROUP_ID,
-            enabled: true,
-            matchMode: 'contains',
-            blockType: 'block',
-          },
-        ],
-      }),
-      { context: activeContext }
-    );
-
-    expect(decision).toEqual({
-      action: 'block',
-      filterId: 'block-filter',
-      groupId: DEFAULT_GROUP_ID,
-      blockType: 'block',
       reason: 'matched-filter',
     });
   });

--- a/test/unit/shared/filters.test.ts
+++ b/test/unit/shared/filters.test.ts
@@ -29,7 +29,6 @@ function findBlockingFilter(
       filters,
       whitelist,
       snooze: { active: false },
-      blockType: 'block',
       rulesVersion: 0,
     },
     { context }

--- a/test/unit/shared/session.test.ts
+++ b/test/unit/shared/session.test.ts
@@ -2,17 +2,17 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   clearBlockedTabState,
-  clearWarningBypassState,
+  clearBypassState,
   getBlockedPageState,
   getBlockedTabState,
+  getBypassState,
   getLastAllowedUrl,
-  getWarningBypassState,
   setBlockedPageState,
   getSessionSnooze,
   setBlockedTabState,
   setLastAllowedUrl,
   setSessionSnooze,
-  setWarningBypassState,
+  setBypassState,
 } from '../../../src/shared/api/session';
 import { getChromeMock } from '../../fixtures/chrome-mocks';
 
@@ -33,7 +33,6 @@ describe('shared/api/session', () => {
       blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 5,
       blockedBy: {
@@ -46,7 +45,6 @@ describe('shared/api/session', () => {
       blockId: 'block-7',
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 5,
       blockedBy: {
@@ -64,7 +62,6 @@ describe('shared/api/session', () => {
       blockId: 'block-page-1',
       tabId: 3,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 6,
       blockedBy: {
@@ -95,7 +92,6 @@ describe('shared/api/session', () => {
       blockId: 'block-page-1',
       tabId: 3,
       targetUrl: 'https://blocked.com/focus',
-      blockType: 'block',
       blockedAt: 1234,
       rulesVersion: 6,
       blockedBy: {
@@ -135,19 +131,19 @@ describe('shared/api/session', () => {
     await expect(getSessionSnooze()).resolves.toEqual({ active: false });
   });
 
-  it('stores, retrieves, and clears warning bypass state by tab id', async () => {
-    await setWarningBypassState(9, {
-      filterId: 'warning-filter',
-      urlKey: 'https://warning.example.test',
+  it('stores, retrieves, and clears bypass state by tab id', async () => {
+    await setBypassState(9, {
+      filterId: 'bypassed-filter',
+      urlKey: 'https://bypass.example.test',
     });
 
-    await expect(getWarningBypassState(9)).resolves.toEqual({
-      filterId: 'warning-filter',
-      urlKey: 'https://warning.example.test',
+    await expect(getBypassState(9)).resolves.toEqual({
+      filterId: 'bypassed-filter',
+      urlKey: 'https://bypass.example.test',
     });
 
-    await clearWarningBypassState(9);
-    await expect(getWarningBypassState(9)).resolves.toBeUndefined();
+    await clearBypassState(9);
+    await expect(getBypassState(9)).resolves.toBeUndefined();
   });
 
   it('ignores malformed session snooze values', async () => {

--- a/test/unit/shared/storage.test.ts
+++ b/test/unit/shared/storage.test.ts
@@ -35,7 +35,6 @@ describe('storage', () => {
         filters: [],
         whitelist: [],
         snooze: { active: false },
-        blockType: 'block',
         expandBlockPageDetails: false,
         rulesVersion: 0,
       });
@@ -58,12 +57,10 @@ describe('storage', () => {
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains' as const,
-            blockType: 'default' as const,
           },
         ],
         whitelist: [],
         snooze: { active: false },
-        blockType: 'warning' as const,
         expandBlockPageDetails: true,
         rulesVersion: 2,
       };
@@ -134,7 +131,6 @@ describe('storage', () => {
       const data = await loadData();
       expect(data.whitelist).toEqual([]);
       expect(data.snooze).toEqual({ active: false });
-      expect(data.blockType).toBe('block');
       expect(data.rulesVersion).toBe(0);
     });
 
@@ -172,7 +168,6 @@ describe('storage', () => {
 
       const data = await loadData();
       expect(data.filters[0]?.matchMode).toBe('regex');
-      expect(data.filters[0]?.blockType).toBe('default');
     });
 
     it('should default whitelist match mode to contains', async () => {
@@ -234,7 +229,6 @@ describe('storage', () => {
             groupId: 'missing-group',
             enabled: true,
             matchMode: 'regex',
-            blockType: 'default',
           },
         ],
         whitelist: [
@@ -247,13 +241,12 @@ describe('storage', () => {
           },
         ],
         snooze: { active: true },
-        blockType: 'block',
         expandBlockPageDetails: false,
         rulesVersion: 0,
       });
     });
 
-    it('defaults missing block type values for storage and filters', async () => {
+    it('strips retired block type values from storage and filters', async () => {
       getChromeMock().storage.sync._data.set(STORAGE_KEY, {
         groups: [createDefaultGroup()],
         filters: [
@@ -263,13 +256,15 @@ describe('storage', () => {
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains',
+            blockType: 'warning',
           },
         ],
+        blockType: 'warning',
       });
 
       const data = await loadData();
-      expect(data.blockType).toBe('block');
-      expect(data.filters[0]?.blockType).toBe('default');
+      expect(data).not.toHaveProperty('blockType');
+      expect(data.filters[0]).not.toHaveProperty('blockType');
     });
 
     it('defaults the expand block page details setting to false', async () => {
@@ -349,7 +344,7 @@ describe('storage', () => {
         createDefaultGroup(),
         { ...group, name: 'Updated Group', enabled: true },
       ]);
-      expect(data.filters).toEqual([{ ...filter, enabled: false, blockType: 'default' }]);
+      expect(data.filters).toEqual([{ ...filter, enabled: false }]);
 
       await deleteFilter(filter.id);
 

--- a/test/unit/shared/storageImportExport.test.ts
+++ b/test/unit/shared/storageImportExport.test.ts
@@ -30,7 +30,6 @@ function createSampleData(): StorageData {
         groupId: DEFAULT_GROUP_ID,
         enabled: true,
         matchMode: 'contains',
-        blockType: 'default',
         description: 'News',
       },
       {
@@ -39,7 +38,6 @@ function createSampleData(): StorageData {
         groupId: 'work-hours',
         enabled: true,
         matchMode: 'regex',
-        blockType: 'default',
       },
     ],
     whitelist: [
@@ -52,7 +50,6 @@ function createSampleData(): StorageData {
       },
     ],
     snooze: { active: true, until: 1_234_567_890 },
-    blockType: 'block',
     expandBlockPageDetails: false,
     rulesVersion: 4,
   };
@@ -118,7 +115,6 @@ describe('storage import/export', () => {
         },
       ],
       snooze: { active: false },
-      blockType: 'block',
       rulesVersion: 0,
     });
   });


### PR DESCRIPTION
Simplifies the app by removing the block-type concept introduced in #102, both globally and per filter. Every block now renders the same block page, and a **Continue** button — tucked behind the **Learn more** link from #111 — lets the user bypass any block.

## What changed

- **Storage & types**: Removed `BlockType`/`FilterBlockType` and the `blockType` fields from `Filter`, `StorageData`, and `BlockedTabState`. `WarningBypassState` is renamed to `BypassState`. Legacy `blockType` values are silently stripped when loading or importing old data, so existing installs and old export files keep working.
- **Filtering engine**: Back to first-match-wins — the warning-vs-hard-block precedence pass is gone and `FilterDecision` no longer carries a block type.
- **Background**: `TabController` drops all warning branching; the bypass check applies to every block decision and `continueFromTab` works for any blocked URL. Bypass scope is unchanged: same tab, same responsible filter, same URL origin, persisted per tab session.
- **Options UI**: The global **Block Type** dropdown and the per-filter **Block Type** select are removed. The block-page preview no longer varies by type (`?preview=1`).
- **Blocked page**: Continue shows for every real (or preview) block, inside the collapsed Learn more extras.

## Tests

- Deleted tests for the retired semantics (global warning inheritance, hard-block-over-warning precedence, options block-type persistence).
- Renamed the warning-bypass coverage to plain bypass coverage; the "hard block overrides warning bypass" scenario is replaced by its closest equivalent under the new model: a bypassed tab is re-blocked when a *different* filter becomes responsible.
- Full suite passes: typecheck (src + test), ESLint, Prettier, 159 unit tests, 43 Playwright e2e tests.

## Reviewer note

Since the bypass is keyed to the responsible filter, blocking is now purely friction-based — there is no longer a configuration that produces an un-bypassable block. That is the intended consequence of reverting #102.