### PR TITLE
Freeze block page state at the time of the block

### DIFF
--- a/src/background/handlers/messages.ts
+++ b/src/background/handlers/messages.ts
@@ -101,7 +101,7 @@ async function handleGetBlockedPageState(
 ): Promise<void> {
   const senderTabId = sender.tab?.id;
   if (typeof senderTabId === 'number') {
-    sendResponse(await getTabController().getFreshBlockedPageState(senderTabId, sender.tab?.url));
+    sendResponse(await getTabController().getBlockedPageStateForTab(senderTabId, sender.tab?.url));
     return;
   }
 

--- a/src/background/tabController.ts
+++ b/src/background/tabController.ts
@@ -27,9 +27,7 @@ import { getRulesProvider, type CurrentRules, type RulesProvider } from './rules
 
 interface ResolvedBlockedTarget {
   readonly targetUrl: string;
-  readonly blockId?: string;
   readonly tabId?: number;
-  readonly hasSessionState: boolean;
 }
 
 interface BlockedStateResult {
@@ -93,64 +91,27 @@ class TabController {
     return rules.engine.evaluate(url);
   }
 
-  async restoreIfAllowed(tabId: number, blockedPageUrl?: string): Promise<boolean> {
-    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
-    if (!resolvedTarget) {
-      return false;
-    }
-
-    const rules = await this.getRules();
-    const decision = rules.engine.evaluate(resolvedTarget.targetUrl);
-    const bypassed =
-      decision.action === 'block' &&
-      (await this.isBypassed(tabId, resolvedTarget.targetUrl, decision));
-    if (decision.action === 'block' && !bypassed) {
-      await this.ensureBlockedState(tabId, resolvedTarget.targetUrl, decision, rules.data);
-      return false;
-    }
-
-    await updateTabUrl(tabId, resolvedTarget.targetUrl);
-    await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveBypass: bypassed });
-    return true;
-  }
-
-  async getFreshBlockedTabState(
-    tabId: number,
-    blockedPageUrl?: string
-  ): Promise<BlockedTabState | undefined> {
-    if (!Number.isInteger(tabId)) {
-      return undefined;
-    }
-
-    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
-    if (!resolvedTarget) {
-      return undefined;
-    }
-
-    const state = await this.ensureFreshBlockedState(tabId, resolvedTarget.targetUrl);
-    return state?.tabState;
-  }
-
-  async getFreshBlockedPageState(
+  /**
+   * Look up the snapshot captured when the tab was blocked. The snapshot is intentionally never
+   * re-evaluated against current settings; if the block ends, reconciliation redirects the tab.
+   */
+  async getBlockedPageStateForTab(
     tabId: number,
     blockedPageUrl?: string
   ): Promise<GetBlockedPageStateResponse> {
-    if (!Number.isInteger(tabId)) {
-      const blockId = parseBlockedPageBlockId(blockedPageUrl);
-      return blockId ? this.getBlockedPageStateByBlockId(blockId) : { status: 'unavailable' };
+    const blockId = parseBlockedPageBlockId(blockedPageUrl);
+    const stateByBlockId = blockId ? await getBlockedPageState(blockId) : undefined;
+    if (stateByBlockId) {
+      return { status: 'blocked', state: stateByBlockId };
     }
 
-    const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
-    if (!resolvedTarget) {
+    if (!Number.isInteger(tabId)) {
       return { status: 'unavailable' };
     }
 
-    const state = await this.ensureFreshBlockedState(tabId, resolvedTarget.targetUrl);
-    if (state) {
-      return { status: 'blocked', state: state.pageState };
-    }
-
-    return { status: 'allowed', targetUrl: resolvedTarget.targetUrl };
+    const tabState = await getBlockedTabState(tabId);
+    const pageState = tabState ? await getBlockedPageState(tabState.blockId) : undefined;
+    return pageState ? { status: 'blocked', state: pageState } : { status: 'unavailable' };
   }
 
   async getBlockedPageStateByBlockId(
@@ -273,6 +234,10 @@ class TabController {
     await this.evaluateNavigation(tabId, url);
   }
 
+  /**
+   * An open blocked tab keeps showing the snapshot captured when the block happened; the only
+   * settings-driven change is redirecting back to the target once the block ends.
+   */
   private async reconcileBlockedTab(tabId: number, blockedPageUrl?: string): Promise<void> {
     const resolvedTarget = await this.resolveBlockedTarget(tabId, blockedPageUrl);
     if (!resolvedTarget) {
@@ -284,23 +249,12 @@ class TabController {
     const bypassed =
       decision.action === 'block' &&
       (await this.isBypassed(tabId, resolvedTarget.targetUrl, decision));
-    if (decision.action !== 'block' || bypassed) {
-      if (resolvedTarget.hasSessionState) {
-        await updateTabUrl(tabId, resolvedTarget.targetUrl);
-        await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveBypass: bypassed });
-      }
+    if (decision.action === 'block' && !bypassed) {
       return;
     }
 
-    const state = await this.ensureBlockedState(
-      tabId,
-      resolvedTarget.targetUrl,
-      decision,
-      rules.data
-    );
-    if (blockedPageUrl && parseBlockedPageBlockId(blockedPageUrl) !== state.tabState.blockId) {
-      await updateTabUrl(tabId, getBlockedPageUrl(state.tabState.blockId));
-    }
+    await updateTabUrl(tabId, resolvedTarget.targetUrl);
+    await this.allowTab(tabId, resolvedTarget.targetUrl, { preserveBypass: bypassed });
   }
 
   private async blockTab(
@@ -309,7 +263,7 @@ class TabController {
     decision: Extract<FilterDecision, { action: 'block' }>,
     data: StorageData
   ): Promise<void> {
-    const state = await this.setBlockedState(tabId, url, decision, data);
+    const state = await this.ensureBlockedState(tabId, url, decision, data);
     await updateTabUrl(tabId, getBlockedPageUrl(state.tabState.blockId));
   }
 
@@ -345,7 +299,6 @@ class TabController {
       tabId,
       targetUrl,
       blockedAt: Date.now(),
-      rulesVersion: data.rulesVersion,
       blockedBy: {
         filterId: decision.filterId,
         groupId: decision.groupId,
@@ -379,9 +332,7 @@ class TabController {
       if (pageState) {
         return {
           targetUrl: pageState.targetUrl,
-          blockId,
           tabId: pageState.tabId,
-          hasSessionState: true,
         };
       }
     }
@@ -389,28 +340,16 @@ class TabController {
     return existingState
       ? {
           targetUrl: existingState.targetUrl,
-          blockId: existingState.blockId,
           tabId: existingState.tabId,
-          hasSessionState: true,
         }
       : undefined;
   }
 
-  private async ensureFreshBlockedState(
-    tabId: number,
-    targetUrl: string,
-    currentRules?: CurrentRules
-  ): Promise<BlockedStateResult | undefined> {
-    const rules = currentRules ?? (await this.getRules());
-    const decision = rules.engine.evaluate(targetUrl);
-    if (decision.action !== 'block' || (await this.isBypassed(tabId, targetUrl, decision))) {
-      await clearBlockedTabState(tabId);
-      return undefined;
-    }
-
-    return this.ensureBlockedState(tabId, targetUrl, decision, rules.data);
-  }
-
+  /**
+   * Reuse the existing block for repeat navigations to the same target (e.g. the browser back
+   * button re-committing the blocked URL) so the tab returns to the same blocked page and keeps
+   * the snapshot from the original block instead of filtering again.
+   */
   private async ensureBlockedState(
     tabId: number,
     targetUrl: string,
@@ -418,10 +357,7 @@ class TabController {
     data: StorageData
   ): Promise<BlockedStateResult> {
     const existingState = await getBlockedTabState(tabId);
-    if (
-      existingState &&
-      isSameBlockedState(existingState, targetUrl, decision, data.rulesVersion)
-    ) {
+    if (existingState?.targetUrl === targetUrl) {
       const pageState = await getBlockedPageState(existingState.blockId);
       if (pageState) {
         return { tabState: existingState, pageState };
@@ -483,20 +419,6 @@ function getBlockedPageUrl(blockId: string): string {
 function createBlockId(): string {
   return (
     globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
-  );
-}
-
-function isSameBlockedState(
-  state: BlockedTabState,
-  targetUrl: string,
-  decision: Extract<FilterDecision, { action: 'block' }>,
-  rulesVersion: number
-): boolean {
-  return (
-    state.targetUrl === targetUrl &&
-    state.rulesVersion === rulesVersion &&
-    state.blockedBy.filterId === decision.filterId &&
-    state.blockedBy.groupId === decision.groupId
   );
 }
 

--- a/src/entrypoints/blocked/index.ts
+++ b/src/entrypoints/blocked/index.ts
@@ -20,9 +20,6 @@ interface BlockedPageViewModel {
   readonly state?: BlockedPageState;
 }
 
-/** Once the user clicks "Learn more", keep the extras open across re-renders. */
-let learnMoreClicked = false;
-
 /**
  * Initialize blocked page
  */
@@ -43,7 +40,6 @@ async function init(): Promise<void> {
 
   const learnMoreButton = getElementByIdOrNull('learn-more');
   learnMoreButton?.addEventListener('click', () => {
-    learnMoreClicked = true;
     setExtrasExpanded(true);
   });
 
@@ -55,17 +51,13 @@ async function init(): Promise<void> {
     });
   });
 
-  chrome.storage.onChanged.addListener((_changes, areaName) => {
-    if (areaName !== 'sync' && areaName !== 'session') {
-      return;
-    }
-
-    void renderPage();
-  });
-
   await renderPage();
 }
 
+/**
+ * The page renders once from the snapshot captured at the time of the block and never reacts to
+ * later settings changes; if the block ends, the background redirects this tab to the target.
+ */
 async function renderPage(): Promise<void> {
   const state = await getBlockedPageState();
   renderBlockedUrl(state);
@@ -75,15 +67,10 @@ async function renderPage(): Promise<void> {
 }
 
 /**
- * Details and action buttons stay collapsed behind the "Learn more" link unless the user has
- * expanded them or the global "expand details by default" setting is enabled.
+ * Details and action buttons stay collapsed behind the "Learn more" link unless the global
+ * "expand details by default" setting is enabled.
  */
 async function renderExtrasExpansion(): Promise<void> {
-  if (learnMoreClicked) {
-    setExtrasExpanded(true);
-    return;
-  }
-
   let expandByDefault = false;
   try {
     const data = await loadData();
@@ -131,10 +118,6 @@ async function getBlockedPageState(): Promise<BlockedPageViewModel> {
         state: response.state,
       };
     }
-
-    if (response.status === 'allowed') {
-      return { targetUrl: response.targetUrl };
-    }
   } catch (error: unknown) {
     console.warn('[Teichos] Failed to load blocked tab state:', error);
   }
@@ -181,7 +164,6 @@ function getSampleBlockedPageState(): BlockedPageViewModel {
       targetUrl,
       blockedBy: { filterId: 'preview-filter', groupId: 'preview-group' },
       blockedAt: 0,
-      rulesVersion: 0,
       filter: {
         id: 'preview-filter',
         pattern: 'example.com',
@@ -211,10 +193,6 @@ function isBlockedPageStateResponse(response: unknown): response is GetBlockedPa
 
   if (response.status === 'unavailable') {
     return true;
-  }
-
-  if (response.status === 'allowed') {
-    return 'targetUrl' in response && typeof response.targetUrl === 'string';
   }
 
   return (

--- a/src/shared/api/session.ts
+++ b/src/shared/api/session.ts
@@ -64,7 +64,6 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
     typeof candidate.tabId !== 'number' ||
     typeof candidate.targetUrl !== 'string' ||
     typeof candidate.blockedAt !== 'number' ||
-    typeof candidate.rulesVersion !== 'number' ||
     !candidate.blockedBy ||
     typeof candidate.blockedBy.filterId !== 'string' ||
     typeof candidate.blockedBy.groupId !== 'string'
@@ -77,7 +76,6 @@ function normalizeBlockedTabState(value: unknown): BlockedTabState | undefined {
     tabId: candidate.tabId,
     targetUrl: candidate.targetUrl,
     blockedAt: candidate.blockedAt,
-    rulesVersion: candidate.rulesVersion,
     blockedBy: {
       filterId: candidate.blockedBy.filterId,
       groupId: candidate.blockedBy.groupId,

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -62,10 +62,6 @@ export type GetBlockedPageStateResponse =
       readonly state: BlockedPageState;
     }
   | {
-      readonly status: 'allowed';
-      readonly targetUrl: string;
-    }
-  | {
       readonly status: 'unavailable';
     };
 

--- a/src/shared/types/storage.ts
+++ b/src/shared/types/storage.ts
@@ -67,7 +67,6 @@ export interface BlockedTabState {
   readonly targetUrl: string;
   readonly blockedBy: BlockedBy;
   readonly blockedAt: number;
-  readonly rulesVersion: number;
 }
 
 export interface BlockedFilterSnapshot {

--- a/test/unit/background/messages.test.ts
+++ b/test/unit/background/messages.test.ts
@@ -6,7 +6,7 @@ const mocks = vi.hoisted(() => ({
   continueFromTab: vi.fn(),
   getUrlDecision: vi.fn(),
   getBlockedPageStateByBlockId: vi.fn(),
-  getFreshBlockedPageState: vi.fn(),
+  getBlockedPageStateForTab: vi.fn(),
   goBackFromActiveTab: vi.fn(),
   goBackFromTab: vi.fn(),
   loadData: vi.fn(),
@@ -16,7 +16,7 @@ vi.mock('../../../src/background/tabController', () => ({
   getTabController: (): {
     getUrlDecision: typeof mocks.getUrlDecision;
     getBlockedPageStateByBlockId: typeof mocks.getBlockedPageStateByBlockId;
-    getFreshBlockedPageState: typeof mocks.getFreshBlockedPageState;
+    getBlockedPageStateForTab: typeof mocks.getBlockedPageStateForTab;
     goBackFromActiveTab: typeof mocks.goBackFromActiveTab;
     goBackFromTab: typeof mocks.goBackFromTab;
     continueFromActiveTab: typeof mocks.continueFromActiveTab;
@@ -28,7 +28,7 @@ vi.mock('../../../src/background/tabController', () => ({
     continueFromTab: mocks.continueFromTab,
     getUrlDecision: mocks.getUrlDecision,
     getBlockedPageStateByBlockId: mocks.getBlockedPageStateByBlockId,
-    getFreshBlockedPageState: mocks.getFreshBlockedPageState,
+    getBlockedPageStateForTab: mocks.getBlockedPageStateForTab,
     goBackFromActiveTab: mocks.goBackFromActiveTab,
     goBackFromTab: mocks.goBackFromTab,
   }),
@@ -59,7 +59,7 @@ describe('handleMessage', () => {
     mocks.continueFromTab.mockResolvedValue(false);
     mocks.getUrlDecision.mockResolvedValue({ action: 'allow', reason: 'no-match' });
     mocks.getBlockedPageStateByBlockId.mockResolvedValue({ status: 'unavailable' });
-    mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'unavailable' });
+    mocks.getBlockedPageStateForTab.mockResolvedValue({ status: 'unavailable' });
     mocks.goBackFromActiveTab.mockResolvedValue(false);
     mocks.goBackFromTab.mockResolvedValue(false);
   });
@@ -211,7 +211,6 @@ describe('handleMessage', () => {
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
-      rulesVersion: 2,
       blockedBy: {
         filterId: 'filter-1',
         groupId: DEFAULT_GROUP_ID,
@@ -228,7 +227,7 @@ describe('handleMessage', () => {
         snoozeActive: false,
       },
     };
-    mocks.getFreshBlockedPageState.mockResolvedValue({ status: 'blocked', state: blockedState });
+    mocks.getBlockedPageStateForTab.mockResolvedValue({ status: 'blocked', state: blockedState });
     const sendResponse = vi.fn();
 
     expect(
@@ -248,13 +247,13 @@ describe('handleMessage', () => {
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith({ status: 'blocked', state: blockedState });
     });
-    expect(mocks.getFreshBlockedPageState).toHaveBeenCalledWith(
+    expect(mocks.getBlockedPageStateForTab).toHaveBeenCalledWith(
       7,
       'chrome-extension://test-extension-id/blocked.html'
     );
   });
 
-  it('prefers fresh blocked-page state when sender tab is available', async () => {
+  it('prefers tab-scoped blocked-page state when sender tab is available', async () => {
     const sendResponse = vi.fn();
 
     expect(
@@ -272,7 +271,7 @@ describe('handleMessage', () => {
     ).toBe(true);
 
     await vi.waitFor(() => {
-      expect(mocks.getFreshBlockedPageState).toHaveBeenCalledWith(
+      expect(mocks.getBlockedPageStateForTab).toHaveBeenCalledWith(
         8,
         'chrome-extension://test-extension-id/blocked.html?blockId=block-8'
       );
@@ -288,7 +287,6 @@ describe('handleMessage', () => {
         tabId: 8,
         targetUrl: 'https://blocked.com/focus',
         blockedAt: 1234,
-        rulesVersion: 2,
         blockedBy: {
           filterId: 'filter-1',
           groupId: DEFAULT_GROUP_ID,
@@ -323,7 +321,7 @@ describe('handleMessage', () => {
       expect(sendResponse).toHaveBeenCalledWith(response);
     });
     expect(mocks.getBlockedPageStateByBlockId).toHaveBeenCalledWith('block-8');
-    expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+    expect(mocks.getBlockedPageStateForTab).not.toHaveBeenCalled();
   });
 
   it('returns unavailable blocked-page state when the sender tab is unavailable', async () => {
@@ -340,26 +338,8 @@ describe('handleMessage', () => {
     await vi.waitFor(() => {
       expect(sendResponse).toHaveBeenCalledWith({ status: 'unavailable' });
     });
-    expect(mocks.getFreshBlockedPageState).not.toHaveBeenCalled();
+    expect(mocks.getBlockedPageStateForTab).not.toHaveBeenCalled();
     expect(mocks.getBlockedPageStateByBlockId).not.toHaveBeenCalled();
-  });
-
-  it('forwards allowed blocked-page state responses', async () => {
-    const response = { status: 'allowed', targetUrl: 'https://allowed.com/focus' };
-    mocks.getFreshBlockedPageState.mockResolvedValue(response);
-    const sendResponse = vi.fn();
-
-    expect(
-      handleMessage(
-        { type: MessageType.GET_BLOCKED_PAGE_STATE },
-        { id: 'test-extension-id', tab: { id: 8 } as chrome.tabs.Tab },
-        sendResponse
-      )
-    ).toBe(true);
-
-    await vi.waitFor(() => {
-      expect(sendResponse).toHaveBeenCalledWith(response);
-    });
   });
 
   it('ignores unknown messages from this extension', () => {

--- a/test/unit/background/tabController.test.ts
+++ b/test/unit/background/tabController.test.ts
@@ -59,7 +59,6 @@ describe('TabController', () => {
       tabId: 4,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: expect.any(Number),
-      rulesVersion: 7,
       blockedBy: {
         filterId: 'filter-1',
         groupId: DEFAULT_GROUP_ID,
@@ -84,6 +83,39 @@ describe('TabController', () => {
         },
       }),
     });
+  });
+
+  it('reuses the existing block when the same tab re-navigates to the same target', async () => {
+    const chromeMock = getChromeMock();
+    chromeMock.storage.sync._data.set(
+      STORAGE_KEY,
+      createStorageData({
+        filters: [
+          {
+            id: 'filter-1',
+            pattern: 'blocked.com',
+            groupId: DEFAULT_GROUP_ID,
+            enabled: true,
+            matchMode: 'contains',
+          },
+        ],
+      })
+    );
+
+    const { getTabController } = await import('../../../src/background/tabController');
+    await getTabController().evaluateNavigation(4, 'https://blocked.com/focus');
+    const firstState = await getBlockedTabState(4);
+
+    // The browser back button re-commits the blocked target while the tab is still blocked.
+    await getTabController().evaluateNavigation(4, 'https://blocked.com/focus');
+
+    const secondState = await getBlockedTabState(4);
+    expect(secondState?.blockId).toBe(firstState?.blockId);
+    expect(chromeMock.tabs.update).toHaveBeenLastCalledWith(
+      4,
+      { url: blockedPageUrl(firstState!.blockId) },
+      expect.any(Function)
+    );
   });
 
   it('uses a matching regular filter when an earlier temporary match is already expired', async () => {
@@ -121,7 +153,6 @@ describe('TabController', () => {
       tabId: 6,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: expect.any(Number),
-      rulesVersion: 8,
       blockedBy: {
         filterId: 'regular-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -141,7 +172,7 @@ describe('TabController', () => {
     await expect(getLastAllowedUrl(9)).resolves.toBe('https://allowed.com');
   });
 
-  it('restores blocked tabs when current rules allow them', async () => {
+  it('redirects blocked tabs to the target when current rules allow them', async () => {
     const chromeMock = getChromeMock();
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
@@ -149,16 +180,13 @@ describe('TabController', () => {
       tabId: 5,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 3,
       blockedBy: {
         filterId: 'filter-1',
         groupId: DEFAULT_GROUP_ID,
       },
     });
 
-    await expect(getTabController().restoreIfAllowed(5, blockedPageUrl('block-5'))).resolves.toBe(
-      true
-    );
+    await getTabController().evaluateNavigation(5, blockedPageUrl('block-5'));
 
     expect(chromeMock.tabs.update).toHaveBeenCalledWith(
       5,
@@ -193,7 +221,6 @@ describe('TabController', () => {
       tabId: 7,
       targetUrl: 'https://stale-blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 8,
       blockedBy: {
         filterId: 'stale-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -204,7 +231,6 @@ describe('TabController', () => {
       tabId: 7,
       targetUrl: 'https://allowed.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 8,
       blockedBy: {
         filterId: 'stale-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -238,49 +264,46 @@ describe('TabController', () => {
     await expect(getLastAllowedUrl(7)).resolves.toBe('https://allowed.com/focus');
   });
 
-  it('returns freshly evaluated blocked tab state for the current blocked page target', async () => {
+  it('returns the stored snapshot without re-evaluating it against current rules', async () => {
     const chromeMock = getChromeMock();
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
       createStorageData({
         filters: [
           {
-            id: 'fresh-filter',
-            pattern: 'fresh-blocked.com',
+            id: 'replacement-filter',
+            pattern: 'still-blocked.com',
             groupId: DEFAULT_GROUP_ID,
             enabled: true,
             matchMode: 'contains',
           },
         ],
-        rulesVersion: 10,
       })
     );
 
     const { getTabController } = await import('../../../src/background/tabController');
     await setBlockedTabState({
-      blockId: 'stale-block',
+      blockId: 'original-block',
       tabId: 10,
-      targetUrl: 'https://stale-blocked.com/focus',
+      targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 9,
       blockedBy: {
-        filterId: 'stale-filter',
+        filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,
       },
     });
     await setBlockedPageState({
-      blockId: 'fresh-block',
+      blockId: 'original-block',
       tabId: 10,
-      targetUrl: 'https://fresh-blocked.com/focus',
+      targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 9,
       blockedBy: {
-        filterId: 'fresh-filter',
+        filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,
       },
       filter: {
-        id: 'fresh-filter',
-        pattern: 'fresh-blocked.com',
+        id: 'original-filter',
+        pattern: 'original-pattern.com',
         matchMode: 'contains',
       },
       group: {
@@ -296,22 +319,25 @@ describe('TabController', () => {
       },
     });
 
+    // The snapshot still names the filter responsible at the time of the block, even though a
+    // different filter would be responsible under the current rules.
     await expect(
-      getTabController().getFreshBlockedTabState(10, blockedPageUrl('fresh-block'))
+      getTabController().getBlockedPageStateForTab(10, blockedPageUrl('original-block'))
     ).resolves.toEqual({
-      blockId: expect.any(String),
-      tabId: 10,
-      targetUrl: 'https://fresh-blocked.com/focus',
-      blockedAt: expect.any(Number),
-      rulesVersion: 10,
-      blockedBy: {
-        filterId: 'fresh-filter',
-        groupId: DEFAULT_GROUP_ID,
-      },
+      status: 'blocked',
+      state: expect.objectContaining({
+        blockId: 'original-block',
+        targetUrl: 'https://still-blocked.com/focus',
+        blockedBy: {
+          filterId: 'original-filter',
+          groupId: DEFAULT_GROUP_ID,
+        },
+        filter: expect.objectContaining({ id: 'original-filter' }),
+      }),
     });
   });
 
-  it('re-evaluates a stale blocked page in place when rules change', async () => {
+  it('leaves a still-blocked page untouched when rules change', async () => {
     const chromeMock = getChromeMock();
     chromeMock.storage.sync._data.set(
       STORAGE_KEY,
@@ -335,7 +361,6 @@ describe('TabController', () => {
       tabId: 11,
       targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 10,
       blockedBy: {
         filterId: 'still-blocking-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -346,7 +371,6 @@ describe('TabController', () => {
       tabId: 11,
       targetUrl: 'https://still-blocked.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 10,
       blockedBy: {
         filterId: 'still-blocking-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -369,23 +393,10 @@ describe('TabController', () => {
       },
     });
 
-    await expect(
-      getTabController().getFreshBlockedPageState(11, blockedPageUrl('stale-block'))
-    ).resolves.toEqual({
-      status: 'blocked',
-      state: expect.objectContaining({
-        targetUrl: 'https://still-blocked.com/focus',
-        rulesVersion: 11,
-        blockedBy: {
-          filterId: 'still-blocking-filter',
-          groupId: DEFAULT_GROUP_ID,
-        },
-      }),
-    });
+    await getTabController().evaluateNavigation(11, blockedPageUrl('stale-block'));
 
-    const refreshedState = await getBlockedTabState(11);
-    expect(refreshedState?.rulesVersion).toBe(11);
-    expect(refreshedState?.blockId).not.toBe('stale-block');
+    const state = await getBlockedTabState(11);
+    expect(state?.blockId).toBe('stale-block');
     expect(chromeMock.tabs.update).not.toHaveBeenCalled();
   });
 
@@ -422,7 +433,6 @@ describe('TabController', () => {
       tabId: 12,
       targetUrl: 'https://bypass.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 12,
       blockedBy: {
         filterId: 'bypassed-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -433,7 +443,6 @@ describe('TabController', () => {
       tabId: 12,
       targetUrl: 'https://bypass.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 12,
       blockedBy: {
         filterId: 'bypassed-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -511,7 +520,6 @@ describe('TabController', () => {
       tabId: 14,
       targetUrl: 'https://override.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 13,
       blockedBy: {
         filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,
@@ -522,7 +530,6 @@ describe('TabController', () => {
       tabId: 14,
       targetUrl: 'https://override.com/focus',
       blockedAt: Date.now(),
-      rulesVersion: 13,
       blockedBy: {
         filterId: 'original-filter',
         groupId: DEFAULT_GROUP_ID,

--- a/test/unit/shared/session.test.ts
+++ b/test/unit/shared/session.test.ts
@@ -34,7 +34,6 @@ describe('shared/api/session', () => {
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
-      rulesVersion: 5,
       blockedBy: {
         filterId: 'filter-1',
         groupId: 'group-1',
@@ -46,7 +45,6 @@ describe('shared/api/session', () => {
       tabId: 7,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
-      rulesVersion: 5,
       blockedBy: {
         filterId: 'filter-1',
         groupId: 'group-1',
@@ -63,7 +61,6 @@ describe('shared/api/session', () => {
       tabId: 3,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
-      rulesVersion: 6,
       blockedBy: {
         filterId: 'filter-1',
         groupId: 'group-1',
@@ -93,7 +90,6 @@ describe('shared/api/session', () => {
       tabId: 3,
       targetUrl: 'https://blocked.com/focus',
       blockedAt: 1234,
-      rulesVersion: 6,
       blockedBy: {
         filterId: 'filter-1',
         groupId: 'group-1',


### PR DESCRIPTION
## What changed

The open blocked tab now keeps the snapshot captured when the block happened. Settings changes no longer re-render or re-issue the block page; the only settings-driven change left is redirecting the tab back to its target once the block ends (rules allow it, or it was bypassed via Continue).

- The blocked page renders once and no longer listens to `chrome.storage.onChanged`. Previously, clicking Learn more → Continue wrote bypass state to session storage, which re-rendered the page as "allowed" (details collapsing, buttons vanishing) before the navigation landed. Any settings edit while a block page was open caused similar visible churn.
- `GET_BLOCKED_PAGE_STATE` returns the stored snapshot by blockId instead of re-evaluating current rules and minting a fresh state on every request.
- Reconciliation leaves a still-blocked tab completely alone when settings change — no new blockId, no URL rewrite, no snapshot refresh.
- Repeat navigations to the same blocked target in the same tab reuse the existing block instead of filtering again with a new blockId. This is the browser back button / Alt+Left path: each back-press used to re-run the filter and mint a new `blocked.html?blockId=...` URL (a new history entry showing potentially different details); now it returns to the identical blocked page with the original snapshot.

## Removed dead code

Freezing the snapshot made several things unreachable, so they are removed: `rulesVersion` on block states (it only existed to detect "stale" snapshots that are no longer refreshed), the `allowed` response variant of `GET_BLOCKED_PAGE_STATE`, and the test-only `restoreIfAllowed`/`getFreshBlockedTabState` methods. Net −124 lines in `src`.

## Notes for review

- Redirect-when-block-ends behavior is unchanged and still covered by the lifecycle e2e tests (filter disable, whitelist, snooze, group toggle).
- The back button still can't hop *over* the blocked target to the last allowed page the way the Go Back button does — `chrome.tabs.update` can't replace history entries — but it no longer re-filters or piles up new entries.
- Verified with `check:fast` (format, lint, typechecks, 159 unit tests) and the full Playwright e2e suite (43 passed).
