### PR TITLE
Rework layout across all UI surfaces for coherence

### DIFF
--- a/src/entrypoints/blocked/index.html
+++ b/src/entrypoints/blocked/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Page Blocked - Teichos</title>
+    <title>Blocked · Teichos</title>
     <link rel="stylesheet" href="styles/blocked.css" />
   </head>
   <body>
@@ -47,8 +47,8 @@
           </dl>
         </section>
         <div class="actions">
-          <button class="button" id="continue" type="button" hidden>Continue</button>
           <button class="button" id="go-back" type="button">Go Back</button>
+          <button class="button secondary" id="continue" type="button" hidden>Continue</button>
           <button class="button secondary" id="open-options" type="button">Manage Filters</button>
         </div>
       </div>

--- a/src/entrypoints/blocked/styles/blocked.css
+++ b/src/entrypoints/blocked/styles/blocked.css
@@ -1,33 +1,43 @@
-* {
-  box-sizing: border-box;
-}
+@import '../../../shared/styles/theme.css';
 
+/* The block page lives on the brand gradient, so it keeps its own on-gradient tokens. */
 :root {
-  color-scheme: light;
   --text-2xl: 2.25rem;
   --text-lg: 1.1rem;
   --text-md: 0.98rem;
-  --bg-glow-primary: rgba(172, 210, 246, 0.3);
-  --bg-glow-secondary: rgba(102, 109, 220, 0.22);
-  --bg-gradient-start: #4e4cd3;
-  --bg-gradient-mid: #666ddc;
-  --bg-gradient-end: #7d8fe5;
   --text-on-bg: #f7f8ff;
   --url-bg: rgba(255, 255, 255, 0.2);
   --url-border: rgba(255, 255, 255, 0.28);
   --detail-bg: rgba(255, 255, 255, 0.16);
   --detail-border: rgba(255, 255, 255, 0.22);
-  --button-bg: #f8fbff;
-  --button-text: #4e4cd3;
-  --button-bg-hover: #ecefff;
-  --button-alt-bg: rgba(255, 255, 255, 0.2);
-  --button-alt-bg-hover: rgba(255, 255, 255, 0.3);
-  --button-alt-text: #f6fbff;
-  --focus-ring: rgba(240, 248, 255, 0.9);
+  --page-button-bg: #f8fbff;
+  --page-button-text: #4e4cd3;
+  --page-button-bg-hover: #ecefff;
+  --page-button-alt-bg: rgba(255, 255, 255, 0.2);
+  --page-button-alt-bg-hover: rgba(255, 255, 255, 0.3);
+  --page-button-alt-text: #f6fbff;
+  --page-focus-ring: rgba(240, 248, 255, 0.9);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text-on-bg: #f0f2ff;
+    --url-bg: rgba(12, 22, 39, 0.44);
+    --url-border: rgba(173, 203, 244, 0.18);
+    --detail-bg: rgba(12, 22, 39, 0.34);
+    --detail-border: rgba(173, 203, 244, 0.18);
+    --page-button-bg: #ddecff;
+    --page-button-text: #3a32a9;
+    --page-button-bg-hover: #cfd8ff;
+    --page-button-alt-bg: rgba(24, 27, 72, 0.52);
+    --page-button-alt-bg-hover: rgba(24, 27, 72, 0.66);
+    --page-button-alt-text: #f0f2ff;
+    --page-focus-ring: rgba(228, 232, 255, 0.9);
+  }
 }
 
 body {
-  font-family: system-ui, sans-serif;
+  font-family: var(--font-sans);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -38,9 +48,9 @@ body {
     radial-gradient(860px 520px at 92% -16%, var(--bg-glow-secondary), transparent 62%),
     linear-gradient(
       135deg,
-      var(--bg-gradient-start) 0%,
-      var(--bg-gradient-mid) 52%,
-      var(--bg-gradient-end) 100%
+      var(--header-gradient-start) 0%,
+      var(--header-gradient-mid) 52%,
+      var(--header-gradient-end) 100%
     );
   color: var(--text-on-bg);
   font-size: 16px;
@@ -67,6 +77,7 @@ body {
 }
 
 h1 {
+  font-family: var(--font-display);
   font-size: var(--text-2xl);
   margin: 0 0 1rem 0;
 }
@@ -76,14 +87,15 @@ p {
   margin: 0 0 2rem 0;
   opacity: 0.9;
 }
+
 .url {
   background: var(--url-bg);
   border: 1px solid var(--url-border);
   padding: 1rem;
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   word-break: break-all;
   margin-bottom: 2rem;
-  font-family: monospace;
+  font-family: var(--font-mono);
   font-size: var(--text-md);
 }
 
@@ -106,7 +118,7 @@ p {
 }
 
 .learn-more:focus-visible {
-  outline: 2px solid var(--focus-ring);
+  outline: 2px solid var(--page-focus-ring);
   outline-offset: 3px;
   border-radius: 4px;
 }
@@ -119,7 +131,7 @@ p {
   margin: 0 0 2rem;
   padding: 1rem;
   border: 1px solid var(--detail-border);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   background: var(--detail-bg);
   text-align: left;
 }
@@ -166,64 +178,36 @@ p {
   flex-wrap: wrap;
 }
 
+/* On-gradient buttons override the shared surface-page styles. */
 .button {
-  display: inline-block;
   padding: 12px 24px;
-  background: var(--button-bg);
-  color: var(--button-text);
-  text-decoration: none;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
+  background: var(--page-button-bg);
+  color: var(--page-button-text);
   border: none;
   font-size: 1rem;
-  transition:
-    background 0.2s,
-    color 0.2s;
+  box-shadow: none;
 }
 
 .button:hover {
-  background: var(--button-bg-hover);
+  background: var(--page-button-bg-hover);
 }
 
 .button:focus-visible {
-  outline: 2px solid var(--focus-ring);
+  outline: 2px solid var(--page-focus-ring);
   outline-offset: 3px;
 }
 
 .button.secondary {
-  background: var(--button-alt-bg);
-  color: var(--button-alt-text);
+  background: var(--page-button-alt-bg);
+  color: var(--page-button-alt-text);
+  border: none;
 }
 
 .button.secondary:hover {
-  background: var(--button-alt-bg-hover);
+  background: var(--page-button-alt-bg-hover);
 }
 
 /* The `.button` display rule outranks the UA `[hidden]` style, so restore hiding explicitly. */
 .button[hidden] {
   display: none;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-    --bg-glow-primary: rgba(102, 109, 220, 0.44);
-    --bg-glow-secondary: rgba(78, 76, 211, 0.36);
-    --bg-gradient-start: #3a32a9;
-    --bg-gradient-mid: #4e4cd3;
-    --bg-gradient-end: #666ddc;
-    --text-on-bg: #f0f2ff;
-    --url-bg: rgba(12, 22, 39, 0.44);
-    --url-border: rgba(173, 203, 244, 0.18);
-    --detail-bg: rgba(12, 22, 39, 0.34);
-    --detail-border: rgba(173, 203, 244, 0.18);
-    --button-bg: #ddecff;
-    --button-text: #3a32a9;
-    --button-bg-hover: #cfd8ff;
-    --button-alt-bg: rgba(24, 27, 72, 0.52);
-    --button-alt-bg-hover: rgba(24, 27, 72, 0.66);
-    --button-alt-text: #f0f2ff;
-    --focus-ring: rgba(228, 232, 255, 0.9);
-  }
 }

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="manifest.open_in_tab" content="true" />
-    <title>Teichos Options</title>
+    <title>Settings · Teichos</title>
     <link rel="stylesheet" href="styles/options.css" />
   </head>
   <body>
@@ -15,7 +15,7 @@
             <img class="app-icon" src="/assets/icons/icon.svg" alt="" />
             Teichos
           </h1>
-          <p class="subtitle">Configure URL filters and time-based blocking schedules</p>
+          <p class="subtitle">Settings — choose what gets blocked and when</p>
         </div>
         <div class="header-actions">
           <div class="info-popover">
@@ -105,39 +105,40 @@
         </div>
       </header>
 
-      <div class="section-header">
-        <h2>Groups</h2>
-      </div>
-      <div id="groups-list"></div>
-      <div class="list-footer">
-        <button class="button" id="add-group-btn">
-          <span class="button-icon" aria-hidden="true">
-            <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
-              <path
-                d="M8 3v10M3 8h10"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-              ></path>
-            </svg>
-          </span>
-          New Group
-        </button>
-      </div>
-
-      <details class="group-item options-placeholder-group" open>
-        <summary class="group-header">
-          <div class="group-info">
-            <div class="group-title">Global Settings</div>
-            <div class="filter-meta">Extension-wide preferences and defaults</div>
-          </div>
-        </summary>
-        <div class="group-content">
-          <div class="global-settings-panel">
-            <p class="global-settings-note">
-              Adjust extension-wide preferences, or export/import your current Teichos
-              configuration.
+      <section class="settings-section" aria-labelledby="groups-heading">
+        <div class="section-header">
+          <div class="section-heading-block">
+            <h2 id="groups-heading">Groups</h2>
+            <p class="section-hint">
+              Each group holds filters and exceptions, and decides when they apply.
             </p>
+          </div>
+          <button class="button" id="add-group-btn">
+            <span class="button-icon" aria-hidden="true">
+              <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
+                <path
+                  d="M8 3v10M3 8h10"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                ></path>
+              </svg>
+            </span>
+            New Group
+          </button>
+        </div>
+        <div id="groups-list"></div>
+      </section>
+
+      <section class="settings-section" aria-labelledby="general-heading">
+        <div class="section-header">
+          <div class="section-heading-block">
+            <h2 id="general-heading">General</h2>
+            <p class="section-hint">Extension-wide preferences and backups.</p>
+          </div>
+        </div>
+        <div class="settings-card">
+          <div class="global-settings-panel">
             <div class="form-row">
               <label class="checkbox-label">
                 <input type="checkbox" id="global-expand-details" />
@@ -169,7 +170,7 @@
             ></p>
           </div>
         </div>
-      </details>
+      </section>
     </div>
 
     <template id="options-group-template">

--- a/src/entrypoints/options/index.html
+++ b/src/entrypoints/options/index.html
@@ -15,7 +15,6 @@
             <img class="app-icon" src="/assets/icons/icon.svg" alt="" />
             Teichos
           </h1>
-          <p class="subtitle">Settings — choose what gets blocked and when</p>
         </div>
         <div class="header-actions">
           <div class="info-popover">

--- a/src/entrypoints/options/styles/options.css
+++ b/src/entrypoints/options/styles/options.css
@@ -36,7 +36,7 @@ body {
   );
   color: var(--header-text);
   border-radius: var(--radius-lg);
-  padding: 1rem 1.35rem;
+  padding: 0.85rem 1.35rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -48,8 +48,7 @@ body {
 .title-block {
   min-width: 0;
   display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+  align-items: center;
 }
 
 .page-header .app-title {
@@ -63,12 +62,6 @@ body {
   width: 30px;
   height: 30px;
   filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.2));
-}
-
-.subtitle {
-  margin: 0;
-  color: var(--header-subtitle);
-  font-size: 0.9rem;
 }
 
 .header-actions {
@@ -360,12 +353,17 @@ label {
 }
 
 .group-header::after {
-  content: '▾';
-  color: var(--text-muted);
-  transition: transform 0.2s;
-  font-size: 1.3rem;
-  line-height: 1;
+  content: '';
+  width: 16px;
+  height: 16px;
+  flex: 0 0 auto;
   margin-left: 0.75rem;
+  background-color: var(--text-muted);
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 6l4 4 4-4' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M4 6l4 4 4-4' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E")
+    center / contain no-repeat;
+  transition: transform 0.2s;
 }
 
 .group-item[open] .group-header::after {

--- a/src/entrypoints/options/styles/options.css
+++ b/src/entrypoints/options/styles/options.css
@@ -1,73 +1,9 @@
-* {
-  box-sizing: border-box;
-}
+@import '../../../shared/styles/theme.css';
 
 html {
   height: 100%;
   overflow-y: scroll;
   background-color: var(--bg);
-}
-
-:root {
-  color-scheme: light;
-  --font-sans:
-    'Avenir Next', 'SF Pro Text', 'Segoe UI Variable', 'Segoe UI', 'Noto Sans', sans-serif;
-  --font-display:
-    'Space Grotesk', 'Avenir Next', 'SF Pro Display', 'Segoe UI Variable', 'Segoe UI', sans-serif;
-  --text-primary: #0f172a;
-  --text-secondary: #44556f;
-  --text-muted: #7689a8;
-  --bg: #f3f7fc;
-  --surface: #ffffff;
-  --surface-muted: #f3f7ff;
-  --border: #d7e1ef;
-  --accent: #666ddc;
-  --accent-strong: #7d8fe5;
-  --accent-deep: #4e4cd3;
-  --button-primary-bg: #666ddc;
-  --button-primary-hover-bg: #5a61cf;
-  --button-primary-text: #f7f8ff;
-  --button-primary-border: rgba(78, 76, 211, 0.42);
-  --button-primary-shadow: none;
-  --danger: #ef4444;
-  --danger-hover: #dc2626;
-  --bg-glow-primary: rgba(172, 210, 246, 0.28);
-  --bg-glow-secondary: rgba(102, 109, 220, 0.2);
-  --header-gradient-start: #4e4cd3;
-  --header-gradient-mid: #666ddc;
-  --header-gradient-end: #7d8fe5;
-  --header-text: #f7f8ff;
-  --header-subtitle: rgba(247, 248, 255, 0.92);
-  --header-control-bg: rgba(255, 255, 255, 0.17);
-  --header-control-border: rgba(255, 255, 255, 0.45);
-  --header-control-bg-hover: rgba(255, 255, 255, 0.28);
-  --header-control-border-hover: rgba(255, 255, 255, 0.72);
-  --header-focus-ring: rgba(240, 248, 255, 0.94);
-  --panel-soft: #f5f6ff;
-  --panel-soft-hover: #eaeeff;
-  --panel-soft-active: #dde3ff;
-  --panel-soft-border: rgba(102, 109, 220, 0.42);
-  --panel-soft-text-strong: #2b327d;
-  --group-header-start: #fafbff;
-  --group-header-end: #f0f3ff;
-  --overlay-muted: rgba(149, 165, 232, 0.35);
-  --focus-ring: rgba(102, 109, 220, 0.68);
-  --focus-ring-soft: rgba(102, 109, 220, 0.28);
-  --toggle-track: #b9c0ea;
-  --toggle-thumb: #ffffff;
-  --info-badge-bg: #303a8f;
-  --info-badge-text: #f7f8ff;
-  --info-badge-shadow: 0 10px 24px rgba(40, 44, 118, 0.26);
-  --info-badge-shadow-hover: 0 12px 28px rgba(40, 44, 118, 0.32);
-  --icon-border: #d7e1ef;
-  --icon-color: #5a6298;
-  --header-shadow: 0 14px 34px rgba(48, 43, 126, 0.25);
-  --shadow-sm: 0 8px 20px rgba(38, 41, 102, 0.1);
-  --shadow-lg: 0 20px 50px rgba(35, 38, 98, 0.24);
-  --modal-overlay: rgba(17, 18, 46, 0.58);
-  --radius-lg: 18px;
-  --radius-md: 12px;
-  --radius-sm: 10px;
 }
 
 body {
@@ -86,10 +22,11 @@ body {
 }
 
 .container {
-  max-width: 1100px;
+  max-width: 880px;
   margin: 0 auto;
 }
 
+/* Page header: compact brand bar */
 .page-header {
   background: linear-gradient(
     135deg,
@@ -99,44 +36,39 @@ body {
   );
   color: var(--header-text);
   border-radius: var(--radius-lg);
-  padding: 1.5rem 1.75rem;
+  padding: 1rem 1.35rem;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1.5rem;
   box-shadow: var(--header-shadow);
-  margin-bottom: 1.75rem;
+  margin-bottom: 2rem;
 }
 
 .title-block {
   min-width: 0;
-}
-
-.app-title {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin: 0;
-  font-family: var(--font-display);
-  font-weight: 700;
-  font-size: 1.75rem;
-  line-height: 1;
-  letter-spacing: 0.3px;
+  flex-direction: column;
+  gap: 0.3rem;
 }
 
-.app-icon {
-  width: 36px;
-  height: 36px;
-  display: block;
-  flex: 0 0 36px;
-  transform: translateY(1px);
+.page-header .app-title {
+  font-weight: 700;
+  font-size: 1.45rem;
+  letter-spacing: 0.3px;
+  gap: 0.6rem;
+}
+
+.page-header .app-icon {
+  width: 30px;
+  height: 30px;
   filter: drop-shadow(0 6px 12px rgba(15, 23, 42, 0.2));
 }
 
 .subtitle {
-  margin: 0.4rem 0 0;
+  margin: 0;
   color: var(--header-subtitle);
-  font-size: 0.95rem;
+  font-size: 0.9rem;
 }
 
 .header-actions {
@@ -145,6 +77,7 @@ body {
   gap: 0.6rem;
 }
 
+/* About popover */
 .info-popover {
   position: relative;
 }
@@ -301,6 +234,27 @@ body {
   height: 100%;
 }
 
+/* Sections */
+.settings-section {
+  margin-bottom: 2.25rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.section-heading-block {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
 .section-header h2 {
   margin: 0;
   color: var(--text-primary);
@@ -309,8 +263,18 @@ body {
   font-family: var(--font-display);
 }
 
-.section-header {
-  margin-bottom: 1rem;
+.section-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.88rem;
+}
+
+.settings-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.25rem;
+  box-shadow: var(--shadow-sm);
 }
 
 .list-footer {
@@ -321,147 +285,6 @@ body {
 
 .group-section .list-footer {
   margin-top: 0.65rem;
-}
-
-/* Buttons */
-.button {
-  font-family: var(--font-sans);
-  padding: 0.6rem 1.1rem;
-  background-color: var(--button-primary-bg);
-  color: var(--button-primary-text);
-  border: 1px solid var(--button-primary-border);
-  border-radius: 999px;
-  cursor: pointer;
-  font-size: 0.92rem;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.45rem;
-  line-height: 1;
-  transition:
-    box-shadow 0.2s,
-    background-color 0.2s,
-    border-color 0.2s;
-  box-shadow: var(--button-primary-shadow);
-}
-
-.button + .button {
-  margin-left: 0.5rem;
-}
-
-.actions .button + .button {
-  margin-left: 0;
-}
-
-form .button + .button {
-  margin-left: 0;
-}
-
-.button:hover {
-  background-color: var(--button-primary-hover-bg);
-}
-
-.button:focus-visible,
-.icon-button:focus-visible,
-.close:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
-}
-
-.button.secondary {
-  background: var(--panel-soft);
-  color: var(--text-secondary);
-  border: 1px solid var(--border);
-  box-shadow: none;
-}
-
-.button.secondary:hover {
-  background: var(--panel-soft-hover);
-  border-color: var(--panel-soft-border);
-  color: var(--panel-soft-text-strong);
-}
-
-.button.danger {
-  background: var(--danger);
-  border-color: transparent;
-  box-shadow: none;
-}
-
-.button.danger:hover {
-  background: var(--danger-hover);
-}
-
-.button.small {
-  padding: 0.45rem 0.85rem;
-  font-size: 0.82rem;
-  box-shadow: none;
-}
-
-.icon-button {
-  width: 34px;
-  height: 34px;
-  border-radius: 999px;
-  border: 1px solid var(--icon-border);
-  background: transparent;
-  color: var(--icon-color);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition:
-    background 0.2s,
-    border-color 0.2s,
-    color 0.2s;
-}
-
-.icon-button.small {
-  width: 28px;
-  height: 28px;
-}
-
-.icon-button:hover {
-  background: var(--panel-soft-hover);
-  border-color: var(--panel-soft-border);
-  color: var(--panel-soft-text-strong);
-}
-
-.icon-button:disabled {
-  cursor: default;
-  opacity: 0.5;
-}
-
-.button-icon {
-  display: inline-flex;
-  width: 14px;
-  height: 14px;
-}
-
-.button-icon svg {
-  width: 100%;
-  height: 100%;
-}
-
-.icon-button .button-icon {
-  width: 16px;
-  height: 16px;
-}
-
-.icon-button.small .button-icon {
-  width: 14px;
-  height: 14px;
-}
-
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-  white-space: nowrap;
 }
 
 /* Form elements */
@@ -504,21 +327,17 @@ label {
   gap: 0.4rem;
 }
 
-/* List items */
+/* Group cards */
 .group-item {
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  margin-bottom: 1.25rem;
+  margin-bottom: 1rem;
   overflow: hidden;
   transition:
     border-color 0.2s,
     box-shadow 0.2s;
   box-shadow: var(--shadow-sm);
-}
-
-.options-placeholder-group {
-  margin-top: 1.25rem;
 }
 
 .group-header {
@@ -558,7 +377,7 @@ label {
 }
 
 .group-item.group-disabled .group-header {
-  background: linear-gradient(180deg, var(--surface-alt) 0%, var(--surface) 100%);
+  background: var(--surface);
 }
 
 .group-item.group-disabled .group-title,
@@ -580,38 +399,17 @@ label {
   gap: 0.25rem;
 }
 
+.group-title {
+  font-weight: 700;
+  font-size: 1.1rem;
+  color: var(--text-primary);
+  font-family: var(--font-display);
+}
+
 .group-content {
   padding: 1rem 1.25rem 1.25rem;
   background: var(--surface);
   position: relative;
-}
-
-.global-settings-panel {
-  display: grid;
-  gap: 0.9rem;
-}
-
-.global-settings-note {
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.92rem;
-}
-
-.global-settings-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.global-settings-status {
-  min-height: 1.4rem;
-  margin: 0;
-  color: var(--text-secondary);
-  font-size: 0.88rem;
-}
-
-.global-settings-status.is-error {
-  color: var(--danger-hover);
 }
 
 .group-content.is-snoozed [data-role='filter-list'] {
@@ -665,7 +463,7 @@ label {
 
 .group-section-header h3 {
   margin: 0;
-  font-size: 1.05rem;
+  font-size: 0.98rem;
   color: var(--text-primary);
   font-weight: 600;
   font-family: var(--font-display);
@@ -677,20 +475,20 @@ label {
   color: var(--text-muted);
 }
 
+/* Filter / exception rows */
 .filter-item {
   background: var(--surface);
-  padding: 0.9rem 1rem;
+  padding: 0.75rem 1rem;
   border-radius: var(--radius-md);
   border: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  box-shadow: var(--shadow-sm);
 }
 
 .filter-item + .filter-item {
-  margin-top: 0.65rem;
+  margin-top: 0.5rem;
 }
 
 .filter-details {
@@ -704,18 +502,11 @@ label {
 .filter-title {
   font-weight: 600;
   color: var(--text-primary);
-  font-size: 0.98rem;
-}
-
-.group-title {
-  font-weight: 700;
-  font-size: 1.1rem;
-  color: var(--text-primary);
-  font-family: var(--font-display);
+  font-size: 0.95rem;
 }
 
 .filter-pattern {
-  font-family: 'SFMono-Regular', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
+  font-family: var(--font-mono);
   color: var(--text-secondary);
   font-size: 0.85rem;
   white-space: nowrap;
@@ -747,56 +538,32 @@ label {
   opacity: 0.72;
 }
 
-/* Toggle switch */
-.toggle {
-  position: relative;
-  display: inline-block;
-  width: 46px;
-  height: 24px;
-  flex: 0 0 auto;
+/* Global settings */
+.global-settings-panel {
+  display: grid;
+  gap: 0.9rem;
 }
 
-.toggle input {
-  opacity: 0;
-  width: 0;
-  height: 0;
+.global-settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
-.toggle input:focus-visible + .slider {
-  box-shadow: 0 0 0 3px var(--focus-ring-soft);
+.global-settings-status {
+  min-height: 1.4rem;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.88rem;
 }
 
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: var(--toggle-track);
-  transition: 0.3s;
-  border-radius: 24px;
+/* Collapse the placeholder row until there is a status to show. */
+.global-settings-status:empty {
+  display: none;
 }
 
-.slider:before {
-  position: absolute;
-  content: '';
-  height: 18px;
-  width: 18px;
-  left: 3px;
-  bottom: 3px;
-  background-color: var(--toggle-thumb);
-  transition: 0.3s;
-  border-radius: 50%;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
-}
-
-input:checked + .slider {
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-}
-
-input:checked + .slider:before {
-  transform: translateX(22px);
+.global-settings-status.is-error {
+  color: var(--danger-hover);
 }
 
 /* Modal */
@@ -870,6 +637,11 @@ input:checked + .slider:before {
   color: var(--text-secondary);
 }
 
+.close:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
 /* Checkbox label */
 .checkbox-label {
   display: flex;
@@ -939,7 +711,7 @@ input:checked + .slider:before {
 }
 
 .required-marker {
-  color: #ef4444;
+  color: var(--danger);
   font-weight: 600;
 }
 
@@ -950,6 +722,10 @@ input:checked + .slider:before {
 
   .page-header {
     flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-header {
     align-items: flex-start;
   }
 
@@ -970,62 +746,5 @@ input:checked + .slider:before {
   .global-settings-actions {
     flex-direction: column;
     align-items: stretch;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-    --text-primary: #edf0ff;
-    --text-secondary: #c9d2f6;
-    --text-muted: #9da8d9;
-    --bg: #111328;
-    --surface: #191d3b;
-    --surface-muted: #202657;
-    --border: #343a74;
-    --accent: #95b0ed;
-    --accent-strong: #acd2f6;
-    --accent-deep: #7d8fe5;
-    --button-primary-bg: #6f79de;
-    --button-primary-hover-bg: #646fd8;
-    --button-primary-text: #f0f2ff;
-    --button-primary-border: rgba(172, 210, 246, 0.3);
-    --button-primary-shadow: none;
-    --danger: #f87171;
-    --danger-hover: #ef4444;
-    --bg-glow-primary: rgba(102, 109, 220, 0.42);
-    --bg-glow-secondary: rgba(78, 76, 211, 0.34);
-    --header-gradient-start: #3a32a9;
-    --header-gradient-mid: #4e4cd3;
-    --header-gradient-end: #666ddc;
-    --header-text: #f0f2ff;
-    --header-subtitle: rgba(228, 233, 255, 0.9);
-    --header-control-bg: rgba(219, 225, 255, 0.16);
-    --header-control-border: rgba(187, 199, 255, 0.38);
-    --header-control-bg-hover: rgba(226, 232, 255, 0.26);
-    --header-control-border-hover: rgba(207, 217, 255, 0.6);
-    --header-focus-ring: rgba(228, 232, 255, 0.9);
-    --panel-soft: #202657;
-    --panel-soft-hover: #29306a;
-    --panel-soft-active: #323b7f;
-    --panel-soft-border: rgba(149, 176, 237, 0.58);
-    --panel-soft-text-strong: #e2e8ff;
-    --group-header-start: #252d66;
-    --group-header-end: #1f2658;
-    --overlay-muted: rgba(33, 38, 84, 0.62);
-    --focus-ring: rgba(149, 176, 237, 0.78);
-    --focus-ring-soft: rgba(149, 176, 237, 0.4);
-    --toggle-track: #5962a0;
-    --toggle-thumb: #e0e4fb;
-    --info-badge-bg: #323a8f;
-    --info-badge-text: #f0f2ff;
-    --info-badge-shadow: 0 12px 30px rgba(12, 14, 44, 0.46);
-    --info-badge-shadow-hover: 0 14px 32px rgba(12, 14, 44, 0.52);
-    --icon-border: #3d4486;
-    --icon-color: #b0baea;
-    --header-shadow: 0 16px 36px rgba(7, 8, 24, 0.54);
-    --shadow-sm: 0 10px 24px rgba(7, 8, 24, 0.34);
-    --shadow-lg: 0 24px 58px rgba(7, 8, 24, 0.62);
-    --modal-overlay: rgba(7, 8, 24, 0.76);
   }
 }

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -44,52 +44,20 @@
         aria-controls="snooze-dialog"
         title="Snooze filtering"
       >
-        <svg
-          class="snooze-icon snooze-icon-off"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        >
-          <path
-            d="M9.25 12.2l2.1 2.15 3.4-4.4"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-          <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
-        </svg>
-        <svg
-          class="snooze-icon snooze-icon-on"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-          focusable="false"
-        >
-          <path
-            d="M12 7.25v4.8l3.4 2.15"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-          />
-          <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
-        </svg>
-        <span class="snooze-status">
-          <span class="snooze-status-heading">Filtering</span>
-          <span class="snooze-trigger-text" id="snooze-label">Active</span>
-        </span>
-        <span class="snooze-chevron" aria-hidden="true">
-          <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+        <span class="status-dot" aria-hidden="true"></span>
+        <span class="snooze-trigger-text" id="snooze-label">Active</span>
+        <span class="snooze-hint" aria-hidden="true">
+          <svg class="snooze-hint-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
             <path
-              d="M5.5 3.5L10 8l-4.5 4.5"
+              d="M12 7.25v4.8l3.4 2.15"
               fill="none"
               stroke="currentColor"
-              stroke-width="1.8"
+              stroke-width="2"
               stroke-linecap="round"
-              stroke-linejoin="round"
             />
+            <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
           </svg>
+          Snooze
         </span>
       </button>
       <div class="snooze-dialog" id="snooze-dialog" aria-hidden="true" inert>

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -13,6 +13,144 @@
         Teichos
       </h1>
       <div class="header-actions">
+        <div class="snooze-popover" id="snooze-popover">
+          <button
+            class="snooze-button snooze-trigger"
+            id="open-snooze"
+            type="button"
+            aria-label="Snooze filtering"
+            aria-haspopup="dialog"
+            aria-expanded="false"
+            aria-controls="snooze-dialog"
+            title="Snooze filtering"
+          >
+            <span class="status-dot" aria-hidden="true"></span>
+            <span class="snooze-trigger-text" id="snooze-label">Active</span>
+          </button>
+          <div class="snooze-dialog" id="snooze-dialog" aria-hidden="true" inert>
+            <div
+              class="snooze-dialog-backdrop"
+              data-action="close-snooze-dialog"
+              aria-hidden="true"
+            ></div>
+            <div
+              class="snooze-dialog-panel dialog-panel"
+              role="dialog"
+              aria-labelledby="snooze-dialog-title"
+            >
+              <div class="snooze-dialog-header dialog-header">
+                <div class="dialog-heading">
+                  <div class="snooze-dialog-title dialog-title" id="snooze-dialog-title">
+                    Snooze filtering
+                  </div>
+                  <div class="dialog-subtitle">Pause all filtering for a set time.</div>
+                </div>
+                <button
+                  class="icon-button"
+                  type="button"
+                  data-action="close-snooze-dialog"
+                  aria-label="Close snooze dialog"
+                  title="Close"
+                >
+                  <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
+                    <path
+                      d="M3.5 3.5l9 9M12.5 3.5l-9 9"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="1.6"
+                      stroke-linecap="round"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="snooze-section dialog-section"
+                role="group"
+                aria-label="Quick snooze durations"
+              >
+                <div class="snooze-section-title dialog-section-title">Quick durations</div>
+                <div class="snooze-options">
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="15">
+                    15m
+                  </button>
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="30">
+                    30m
+                  </button>
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="60">
+                    1h
+                  </button>
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="120">
+                    2h
+                  </button>
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="240">
+                    4h
+                  </button>
+                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="480">
+                    8h
+                  </button>
+                  <button
+                    class="snooze-option dialog-chip"
+                    type="button"
+                    data-snooze-minutes="1440"
+                  >
+                    1d
+                  </button>
+                  <button
+                    class="snooze-option dialog-chip"
+                    type="button"
+                    data-snooze-minutes="4320"
+                  >
+                    3d
+                  </button>
+                </div>
+              </div>
+              <div
+                class="snooze-section dialog-section"
+                role="group"
+                aria-label="Custom snooze duration"
+              >
+                <div class="snooze-section-title dialog-section-title">Custom duration</div>
+                <div class="snooze-custom">
+                  <input
+                    class="snooze-custom-input"
+                    type="number"
+                    id="snooze-custom-duration"
+                    min="1"
+                    step="1"
+                    inputmode="numeric"
+                    value="30"
+                    aria-label="Custom snooze duration"
+                  />
+                  <select
+                    class="snooze-custom-unit"
+                    id="snooze-custom-unit"
+                    aria-label="Custom snooze unit"
+                  >
+                    <option value="minutes">Minutes</option>
+                    <option value="hours">Hours</option>
+                    <option value="days">Days</option>
+                  </select>
+                  <button
+                    class="snooze-custom-apply"
+                    type="button"
+                    data-action="apply-custom-snooze"
+                  >
+                    Set
+                  </button>
+                </div>
+              </div>
+              <div class="snooze-dialog-actions dialog-actions">
+                <button
+                  class="snooze-resume button ghost dialog-action-full"
+                  type="button"
+                  data-action="resume-snooze"
+                >
+                  Resume filtering
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
         <button
           class="header-icon-button"
           id="open-options"
@@ -33,145 +171,6 @@
         </button>
       </div>
     </header>
-    <div class="snooze-popover status-bar" id="snooze-popover">
-      <button
-        class="snooze-button snooze-trigger"
-        id="open-snooze"
-        type="button"
-        aria-label="Snooze filtering"
-        aria-haspopup="dialog"
-        aria-expanded="false"
-        aria-controls="snooze-dialog"
-        title="Snooze filtering"
-      >
-        <span class="status-dot" aria-hidden="true"></span>
-        <span class="snooze-trigger-text" id="snooze-label">Active</span>
-        <span class="snooze-hint" aria-hidden="true">
-          <svg class="snooze-hint-icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path
-              d="M12 7.25v4.8l3.4 2.15"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-            <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
-          </svg>
-          Snooze
-        </span>
-      </button>
-      <div class="snooze-dialog" id="snooze-dialog" aria-hidden="true" inert>
-        <div
-          class="snooze-dialog-backdrop"
-          data-action="close-snooze-dialog"
-          aria-hidden="true"
-        ></div>
-        <div
-          class="snooze-dialog-panel dialog-panel"
-          role="dialog"
-          aria-labelledby="snooze-dialog-title"
-        >
-          <div class="snooze-dialog-header dialog-header">
-            <div class="dialog-heading">
-              <div class="snooze-dialog-title dialog-title" id="snooze-dialog-title">
-                Snooze filtering
-              </div>
-              <div class="dialog-subtitle">Pause all filtering for a set time.</div>
-            </div>
-            <button
-              class="icon-button"
-              type="button"
-              data-action="close-snooze-dialog"
-              aria-label="Close snooze dialog"
-              title="Close"
-            >
-              <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
-                <path
-                  d="M3.5 3.5l9 9M12.5 3.5l-9 9"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.6"
-                  stroke-linecap="round"
-                />
-              </svg>
-            </button>
-          </div>
-          <div
-            class="snooze-section dialog-section"
-            role="group"
-            aria-label="Quick snooze durations"
-          >
-            <div class="snooze-section-title dialog-section-title">Quick durations</div>
-            <div class="snooze-options">
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="15">
-                15m
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="30">
-                30m
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="60">
-                1h
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="120">
-                2h
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="240">
-                4h
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="480">
-                8h
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="1440">
-                1d
-              </button>
-              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="4320">
-                3d
-              </button>
-            </div>
-          </div>
-          <div
-            class="snooze-section dialog-section"
-            role="group"
-            aria-label="Custom snooze duration"
-          >
-            <div class="snooze-section-title dialog-section-title">Custom duration</div>
-            <div class="snooze-custom">
-              <input
-                class="snooze-custom-input"
-                type="number"
-                id="snooze-custom-duration"
-                min="1"
-                step="1"
-                inputmode="numeric"
-                value="30"
-                aria-label="Custom snooze duration"
-              />
-              <select
-                class="snooze-custom-unit"
-                id="snooze-custom-unit"
-                aria-label="Custom snooze unit"
-              >
-                <option value="minutes">Minutes</option>
-                <option value="hours">Hours</option>
-                <option value="days">Days</option>
-              </select>
-              <button class="snooze-custom-apply" type="button" data-action="apply-custom-snooze">
-                Set
-              </button>
-            </div>
-          </div>
-          <div class="snooze-dialog-actions dialog-actions">
-            <button
-              class="snooze-resume button ghost dialog-action-full"
-              type="button"
-              data-action="resume-snooze"
-            >
-              Resume filtering
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
     <main class="content">
       <div class="filter-list" id="filter-list" role="list" aria-label="Active filters"></div>
       <div class="quick-add" id="quick-add" aria-hidden="true" inert>

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Teichos: Page Blocker</title>
+    <title>Teichos</title>
     <link rel="stylesheet" href="styles/popup.css" />
   </head>
   <body>
@@ -13,194 +13,6 @@
         Teichos
       </h1>
       <div class="header-actions">
-        <div class="snooze-popover" id="snooze-popover">
-          <button
-            class="snooze-button snooze-trigger"
-            id="open-snooze"
-            type="button"
-            aria-label="Snooze filtering"
-            aria-haspopup="dialog"
-            aria-expanded="false"
-            aria-controls="snooze-dialog"
-            title="Snooze filtering"
-          >
-            <svg
-              class="snooze-icon snooze-icon-off"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path
-                d="M12 7.25v4.8l3.4 2.15"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-              />
-              <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
-            </svg>
-            <svg
-              class="snooze-icon snooze-icon-on"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path
-                d="M9.25 12.2l2.1 2.15 3.4-4.4"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-              />
-              <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
-            </svg>
-            <span class="snooze-trigger-text" id="snooze-label">Active</span>
-          </button>
-          <div class="snooze-dialog" id="snooze-dialog" aria-hidden="true" inert>
-            <div
-              class="snooze-dialog-backdrop"
-              data-action="close-snooze-dialog"
-              aria-hidden="true"
-            ></div>
-            <div
-              class="snooze-dialog-panel dialog-panel"
-              role="dialog"
-              aria-labelledby="snooze-dialog-title"
-            >
-              <div class="snooze-dialog-header dialog-header">
-                <div class="dialog-heading">
-                  <div class="snooze-dialog-title dialog-title" id="snooze-dialog-title">
-                    Snooze filtering
-                  </div>
-                  <div class="dialog-subtitle">Pause all filtering for a set time.</div>
-                </div>
-                <button
-                  class="icon-button"
-                  type="button"
-                  data-action="close-snooze-dialog"
-                  aria-label="Close snooze dialog"
-                  title="Close"
-                >
-                  <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
-                    <path
-                      d="M3.5 3.5l9 9M12.5 3.5l-9 9"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="1.6"
-                      stroke-linecap="round"
-                    />
-                  </svg>
-                </button>
-              </div>
-              <div
-                class="snooze-section dialog-section"
-                role="group"
-                aria-label="Quick snooze durations"
-              >
-                <div class="snooze-section-title dialog-section-title">Quick durations</div>
-                <div class="snooze-options">
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="15">
-                    15m
-                  </button>
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="30">
-                    30m
-                  </button>
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="60">
-                    1h
-                  </button>
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="120">
-                    2h
-                  </button>
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="240">
-                    4h
-                  </button>
-                  <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="480">
-                    8h
-                  </button>
-                  <button
-                    class="snooze-option dialog-chip"
-                    type="button"
-                    data-snooze-minutes="1440"
-                  >
-                    1d
-                  </button>
-                  <button
-                    class="snooze-option dialog-chip"
-                    type="button"
-                    data-snooze-minutes="4320"
-                  >
-                    3d
-                  </button>
-                </div>
-              </div>
-              <div
-                class="snooze-section dialog-section"
-                role="group"
-                aria-label="Custom snooze duration"
-              >
-                <div class="snooze-section-title dialog-section-title">Custom duration</div>
-                <div class="snooze-custom">
-                  <input
-                    class="snooze-custom-input"
-                    type="number"
-                    id="snooze-custom-duration"
-                    min="1"
-                    step="1"
-                    inputmode="numeric"
-                    value="30"
-                    aria-label="Custom snooze duration"
-                  />
-                  <select
-                    class="snooze-custom-unit"
-                    id="snooze-custom-unit"
-                    aria-label="Custom snooze unit"
-                  >
-                    <option value="minutes">Minutes</option>
-                    <option value="hours">Hours</option>
-                    <option value="days">Days</option>
-                  </select>
-                  <button
-                    class="snooze-custom-apply"
-                    type="button"
-                    data-action="apply-custom-snooze"
-                  >
-                    Set
-                  </button>
-                </div>
-              </div>
-              <div class="snooze-dialog-actions dialog-actions">
-                <button
-                  class="snooze-resume button ghost dialog-action-full"
-                  type="button"
-                  data-action="resume-snooze"
-                >
-                  Resume filtering
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-        <button
-          class="header-icon-button"
-          id="open-quick-add"
-          type="button"
-          aria-label="New temporary filter"
-          aria-haspopup="dialog"
-          aria-expanded="false"
-          aria-controls="quick-add"
-          title="New temporary filter"
-        >
-          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
-            <path
-              d="M12 5v14M5 12h14"
-              fill="none"
-              stroke="currentColor"
-              stroke-width="2"
-              stroke-linecap="round"
-            />
-          </svg>
-        </button>
         <button
           class="header-icon-button"
           id="open-options"
@@ -221,6 +33,177 @@
         </button>
       </div>
     </header>
+    <div class="snooze-popover status-bar" id="snooze-popover">
+      <button
+        class="snooze-button snooze-trigger"
+        id="open-snooze"
+        type="button"
+        aria-label="Snooze filtering"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-controls="snooze-dialog"
+        title="Snooze filtering"
+      >
+        <svg
+          class="snooze-icon snooze-icon-off"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M9.25 12.2l2.1 2.15 3.4-4.4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+          <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
+        </svg>
+        <svg
+          class="snooze-icon snooze-icon-on"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          focusable="false"
+        >
+          <path
+            d="M12 7.25v4.8l3.4 2.15"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          />
+          <circle cx="12" cy="12" r="8.25" fill="none" stroke="currentColor" stroke-width="2" />
+        </svg>
+        <span class="snooze-status">
+          <span class="snooze-status-heading">Filtering</span>
+          <span class="snooze-trigger-text" id="snooze-label">Active</span>
+        </span>
+        <span class="snooze-chevron" aria-hidden="true">
+          <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+            <path
+              d="M5.5 3.5L10 8l-4.5 4.5"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.8"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+      </button>
+      <div class="snooze-dialog" id="snooze-dialog" aria-hidden="true" inert>
+        <div
+          class="snooze-dialog-backdrop"
+          data-action="close-snooze-dialog"
+          aria-hidden="true"
+        ></div>
+        <div
+          class="snooze-dialog-panel dialog-panel"
+          role="dialog"
+          aria-labelledby="snooze-dialog-title"
+        >
+          <div class="snooze-dialog-header dialog-header">
+            <div class="dialog-heading">
+              <div class="snooze-dialog-title dialog-title" id="snooze-dialog-title">
+                Snooze filtering
+              </div>
+              <div class="dialog-subtitle">Pause all filtering for a set time.</div>
+            </div>
+            <button
+              class="icon-button"
+              type="button"
+              data-action="close-snooze-dialog"
+              aria-label="Close snooze dialog"
+              title="Close"
+            >
+              <svg viewBox="0 0 16 16" aria-hidden="true" focusable="false" role="img">
+                <path
+                  d="M3.5 3.5l9 9M12.5 3.5l-9 9"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.6"
+                  stroke-linecap="round"
+                />
+              </svg>
+            </button>
+          </div>
+          <div
+            class="snooze-section dialog-section"
+            role="group"
+            aria-label="Quick snooze durations"
+          >
+            <div class="snooze-section-title dialog-section-title">Quick durations</div>
+            <div class="snooze-options">
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="15">
+                15m
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="30">
+                30m
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="60">
+                1h
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="120">
+                2h
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="240">
+                4h
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="480">
+                8h
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="1440">
+                1d
+              </button>
+              <button class="snooze-option dialog-chip" type="button" data-snooze-minutes="4320">
+                3d
+              </button>
+            </div>
+          </div>
+          <div
+            class="snooze-section dialog-section"
+            role="group"
+            aria-label="Custom snooze duration"
+          >
+            <div class="snooze-section-title dialog-section-title">Custom duration</div>
+            <div class="snooze-custom">
+              <input
+                class="snooze-custom-input"
+                type="number"
+                id="snooze-custom-duration"
+                min="1"
+                step="1"
+                inputmode="numeric"
+                value="30"
+                aria-label="Custom snooze duration"
+              />
+              <select
+                class="snooze-custom-unit"
+                id="snooze-custom-unit"
+                aria-label="Custom snooze unit"
+              >
+                <option value="minutes">Minutes</option>
+                <option value="hours">Hours</option>
+                <option value="days">Days</option>
+              </select>
+              <button class="snooze-custom-apply" type="button" data-action="apply-custom-snooze">
+                Set
+              </button>
+            </div>
+          </div>
+          <div class="snooze-dialog-actions dialog-actions">
+            <button
+              class="snooze-resume button ghost dialog-action-full"
+              type="button"
+              data-action="resume-snooze"
+            >
+              Resume filtering
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
     <main class="content">
       <div class="filter-list" id="filter-list" role="list" aria-label="Active filters"></div>
       <div class="quick-add" id="quick-add" aria-hidden="true" inert>
@@ -233,7 +216,7 @@
         >
           <div class="quick-add-header dialog-header">
             <div class="dialog-heading">
-              <div class="quick-add-title dialog-title" id="quick-add-title">Temporary filter</div>
+              <div class="quick-add-title dialog-title" id="quick-add-title">Temporary block</div>
               <div class="quick-add-subtitle dialog-subtitle" id="quick-add-subtitle">
                 Create a short-lived block that expires automatically.
               </div>
@@ -343,6 +326,31 @@
         </div>
       </div>
     </main>
+    <footer class="footer-bar">
+      <button
+        class="button footer-action"
+        id="open-quick-add"
+        type="button"
+        aria-label="New temporary block"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-controls="quick-add"
+        title="New temporary block"
+      >
+        <span class="button-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+            <path
+              d="M12 5v14M5 12h14"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+            />
+          </svg>
+        </span>
+        New temporary block
+      </button>
+    </footer>
     <div id="status-message" class="sr-only" role="status"></div>
     <template id="popup-empty-state-template">
       <div class="empty-state" role="listitem">
@@ -355,130 +363,128 @@
         <div class="filter-info">
           <div class="filter-name"></div>
           <div class="filter-meta"></div>
-        </div>
-        <div class="filter-footer">
           <div class="filter-group"></div>
-          <div class="quick-actions-bottom">
-            <label class="toggle">
-              <input type="checkbox" />
-              <span class="slider"></span>
-            </label>
-            <div class="quick-actions">
-              <button
-                class="icon-button"
-                type="button"
-                data-action="copy-url"
-                aria-label="Copy URL"
-                title="Copy URL"
+        </div>
+        <div class="filter-actions">
+          <div class="quick-actions">
+            <button
+              class="icon-button"
+              type="button"
+              data-action="copy-url"
+              aria-label="Copy URL"
+              title="Copy URL"
+            >
+              <svg
+                class="icon-copy"
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
               >
-                <svg
-                  class="icon-copy"
-                  viewBox="0 0 16 16"
-                  aria-hidden="true"
-                  focusable="false"
-                  role="img"
-                >
-                  <path d="M6 6.5h6v7H6z" fill="none" stroke="currentColor" stroke-width="1.5" />
-                  <path
-                    d="M4 9.5H3.5A1.5 1.5 0 0 1 2 8V3.5A1.5 1.5 0 0 1 3.5 2H8a1.5 1.5 0 0 1 1.5 1.5V4"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <svg
-                  class="icon-tick"
-                  viewBox="0 0 16 16"
-                  aria-hidden="true"
-                  focusable="false"
-                  role="img"
-                >
-                  <path
-                    d="M3.5 8.5l3 3L12.5 5.5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.7"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </button>
-              <button
-                class="icon-button"
-                type="button"
-                data-action="edit-filter"
-                aria-label="Edit Filter"
-                title="Edit Filter"
+                <path d="M6 6.5h6v7H6z" fill="none" stroke="currentColor" stroke-width="1.5" />
+                <path
+                  d="M4 9.5H3.5A1.5 1.5 0 0 1 2 8V3.5A1.5 1.5 0 0 1 3.5 2H8a1.5 1.5 0 0 1 1.5 1.5V4"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <svg
+                class="icon-tick"
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
               >
-                <svg
-                  class="icon-edit"
-                  viewBox="0 0 16 16"
-                  aria-hidden="true"
-                  focusable="false"
-                  role="img"
-                >
-                  <path
-                    d="M3 11.5V13h1.5l7-7-1.5-1.5-7 7z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9.5 4.5l1.5-1.5 1.5 1.5-1.5 1.5-1.5-1.5z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                  />
-                </svg>
-              </button>
-              <button
-                class="icon-button"
-                type="button"
-                data-action="delete-filter"
-                aria-label="Delete Filter"
-                title="Delete Filter"
-                hidden
+                <path
+                  d="M3.5 8.5l3 3L12.5 5.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.7"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
+            <button
+              class="icon-button"
+              type="button"
+              data-action="edit-filter"
+              aria-label="Edit Filter"
+              title="Edit Filter"
+            >
+              <svg
+                class="icon-edit"
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
               >
-                <svg
-                  class="icon-delete"
-                  viewBox="0 0 16 16"
-                  aria-hidden="true"
-                  focusable="false"
-                  role="img"
-                >
-                  <path
-                    d="M3 4.5h10"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                  />
-                  <path
-                    d="M6 4.5V3h4v1.5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                  />
-                  <path
-                    d="M5.5 6v5M10.5 6v5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                  />
-                  <path
-                    d="M4.5 4.5l.7 8.5h5.6l.7-8.5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="1.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </button>
-            </div>
+                <path
+                  d="M3 11.5V13h1.5l7-7-1.5-1.5-7 7z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M9.5 4.5l1.5-1.5 1.5 1.5-1.5 1.5-1.5-1.5z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                />
+              </svg>
+            </button>
+            <button
+              class="icon-button"
+              type="button"
+              data-action="delete-filter"
+              aria-label="Delete Filter"
+              title="Delete Filter"
+              hidden
+            >
+              <svg
+                class="icon-delete"
+                viewBox="0 0 16 16"
+                aria-hidden="true"
+                focusable="false"
+                role="img"
+              >
+                <path
+                  d="M3 4.5h10"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M6 4.5V3h4v1.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M5.5 6v5M10.5 6v5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                />
+                <path
+                  d="M4.5 4.5l.7 8.5h5.6l.7-8.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </button>
           </div>
+          <label class="toggle">
+            <input type="checkbox" />
+            <span class="slider"></span>
+          </label>
         </div>
       </div>
     </template>

--- a/src/entrypoints/popup/index.ts
+++ b/src/entrypoints/popup/index.ts
@@ -228,11 +228,11 @@ function applySnoozeVisualState(snooze: SnoozeState): void {
     quickAddButton.disabled = isActive;
     quickAddButton.setAttribute(
       'aria-label',
-      isActive ? 'Temporary filters are unavailable while snoozed' : 'New temporary filter'
+      isActive ? 'Temporary blocks are unavailable while snoozed' : 'New temporary block'
     );
     quickAddButton.title = isActive
-      ? 'Temporary filters are unavailable while snoozed'
-      : 'New temporary filter';
+      ? 'Temporary blocks are unavailable while snoozed'
+      : 'New temporary block';
   }
 
   if (isActive && quickAddPopover) {

--- a/src/entrypoints/popup/styles/popup.css
+++ b/src/entrypoints/popup/styles/popup.css
@@ -1,67 +1,9 @@
-* {
-  box-sizing: border-box;
-}
+@import '../../../shared/styles/theme.css';
 
 html {
   height: 100%;
   background-color: var(--bg);
   overflow: hidden;
-}
-
-:root {
-  color-scheme: light;
-  --font-sans:
-    'Avenir Next', 'SF Pro Text', 'Segoe UI Variable', 'Segoe UI', 'Noto Sans', sans-serif;
-  --font-display:
-    'Space Grotesk', 'Avenir Next', 'SF Pro Display', 'Segoe UI Variable', 'Segoe UI', sans-serif;
-  --text-primary: #0f172a;
-  --text-secondary: #44556f;
-  --text-muted: #7689a8;
-  --bg: #f3f7fc;
-  --surface: #ffffff;
-  --border: #d7e1ef;
-  --accent: #666ddc;
-  --accent-strong: #7d8fe5;
-  --accent-deep: #4e4cd3;
-  --button-primary-bg: #666ddc;
-  --button-primary-hover-bg: #5a61cf;
-  --button-primary-text: #f7f8ff;
-  --button-primary-border: rgba(78, 76, 211, 0.42);
-  --button-primary-shadow: none;
-  --bg-glow-primary: rgba(172, 210, 246, 0.28);
-  --bg-glow-secondary: rgba(102, 109, 220, 0.2);
-  --header-gradient-start: #4e4cd3;
-  --header-gradient-mid: #666ddc;
-  --header-gradient-end: #7d8fe5;
-  --header-text: #f7f8ff;
-  --header-control-bg: rgba(255, 255, 255, 0.17);
-  --header-control-border: rgba(255, 255, 255, 0.45);
-  --header-control-bg-hover: rgba(255, 255, 255, 0.28);
-  --header-control-border-hover: rgba(255, 255, 255, 0.72);
-  --header-focus-ring: rgba(240, 248, 255, 0.94);
-  --snooze-bg: rgba(172, 210, 246, 0.4);
-  --snooze-border: rgba(196, 243, 255, 0.9);
-  --snooze-text: #24306f;
-  --panel-soft: #f5f6ff;
-  --panel-soft-hover: #eaeeff;
-  --panel-soft-active: #dde3ff;
-  --panel-soft-strong: #2b327d;
-  --panel-soft-border: rgba(102, 109, 220, 0.42);
-  --section-border: rgba(141, 156, 222, 0.29);
-  --section-gradient-start: #fcfcff;
-  --section-gradient-end: #f4f6ff;
-  --modal-overlay: rgba(12, 23, 42, 0.48);
-  --overlay-muted: rgba(149, 165, 232, 0.35);
-  --focus-ring: rgba(102, 109, 220, 0.68);
-  --focus-ring-soft: rgba(102, 109, 220, 0.44);
-  --toggle-track: #b9c0ea;
-  --toggle-thumb: #ffffff;
-  --header-shadow: 0 12px 28px rgba(48, 43, 126, 0.24);
-  --dialog-shadow: 0 20px 40px rgba(34, 35, 94, 0.22);
-  --shadow-sm: 0 6px 16px rgba(38, 41, 102, 0.1);
-  --empty-surface: rgba(255, 255, 255, 0.78);
-  --radius-md: 12px;
-  --radius-sm: 10px;
 }
 
 body {
@@ -84,6 +26,7 @@ body {
   line-height: 1.45;
 }
 
+/* Header: brand + settings only */
 .header {
   background: linear-gradient(
     135deg,
@@ -97,81 +40,25 @@ body {
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
-  border-radius: 0;
   box-shadow: var(--header-shadow);
+  position: relative;
+  z-index: 5;
+  flex-shrink: 0;
+}
+
+.header .app-title {
+  font-size: 1.2rem;
+}
+
+.header .app-icon {
+  width: 22px;
+  height: 22px;
 }
 
 .header-actions {
   display: flex;
   align-items: center;
   gap: 0.4rem;
-}
-
-.snooze-popover {
-  position: relative;
-}
-
-.snooze-button {
-  border: 1px solid var(--header-control-border);
-  border-radius: 999px;
-  background: var(--header-control-bg);
-  color: var(--header-text);
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.36rem 0.62rem;
-  font-family: inherit;
-  font-size: 0.74rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition:
-    background 0.2s,
-    border-color 0.2s,
-    transform 0.2s;
-}
-
-.snooze-button .snooze-icon {
-  width: 15px;
-  height: 15px;
-  flex: 0 0 auto;
-}
-
-.snooze-trigger-text {
-  white-space: nowrap;
-  line-height: 1;
-}
-
-.snooze-button:hover {
-  background: var(--header-control-bg-hover);
-  border-color: var(--header-control-border-hover);
-}
-
-.snooze-button:active {
-  transform: scale(0.96);
-}
-
-.snooze-button:focus-visible {
-  outline: 2px solid var(--header-focus-ring);
-  outline-offset: 2px;
-}
-
-.app-title {
-  margin: 0;
-  font-size: 1.2rem;
-  line-height: 1;
-  font-weight: 600;
-  font-family: var(--font-display);
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-.app-icon {
-  width: 22px;
-  height: 22px;
-  display: block;
-  flex: 0 0 22px;
-  transform: translateY(1px);
 }
 
 .header-icon-button {
@@ -196,6 +83,97 @@ body {
   height: 16px;
 }
 
+.header-icon-button:hover {
+  background: var(--header-control-bg-hover);
+  border-color: var(--header-control-border-hover);
+}
+
+.header-icon-button:active {
+  transform: scale(0.96);
+}
+
+.header-icon-button:focus-visible {
+  outline: 2px solid var(--header-focus-ring);
+  outline-offset: 2px;
+}
+
+/* Status bar: filtering state / snooze entry point */
+.status-bar {
+  position: relative;
+  padding: 0.5rem 0.5rem 0;
+  flex-shrink: 0;
+}
+
+.snooze-button {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.55rem 0.7rem;
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: var(--shadow-sm);
+  transition:
+    background 0.2s,
+    border-color 0.2s;
+}
+
+.snooze-button:hover {
+  background: var(--panel-soft-hover);
+  border-color: var(--panel-soft-border);
+}
+
+.snooze-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.snooze-button .snooze-icon {
+  width: 18px;
+  height: 18px;
+  flex: 0 0 auto;
+  color: var(--accent-deep);
+}
+
+.snooze-status {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.12rem;
+  min-width: 0;
+  text-align: left;
+}
+
+.snooze-status-heading {
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.snooze-trigger-text {
+  white-space: nowrap;
+  line-height: 1;
+}
+
+.snooze-chevron {
+  margin-left: auto;
+  display: inline-flex;
+  color: var(--text-muted);
+}
+
+.snooze-chevron svg {
+  width: 14px;
+  height: 14px;
+}
+
 .snooze-trigger .snooze-icon-on {
   display: none;
 }
@@ -206,6 +184,10 @@ body {
   color: var(--snooze-text);
 }
 
+.snooze-trigger.is-snoozed .snooze-icon {
+  color: currentColor;
+}
+
 .snooze-trigger.is-snoozed .snooze-icon-off {
   display: none;
 }
@@ -214,18 +196,22 @@ body {
   display: block;
 }
 
-.snooze-dialog {
+/* Dialog overlays (snooze + quick add share the pattern) */
+.snooze-dialog,
+.quick-add {
   position: fixed;
   inset: 0;
   pointer-events: none;
   z-index: 12;
 }
 
-.snooze-dialog.is-open {
+.snooze-dialog.is-open,
+.quick-add.is-open {
   pointer-events: auto;
 }
 
-.snooze-dialog-backdrop {
+.snooze-dialog-backdrop,
+.quick-add-backdrop {
   position: absolute;
   inset: 0;
   background: var(--modal-overlay);
@@ -233,8 +219,12 @@ body {
   transition: opacity 0.2s;
 }
 
-.snooze-dialog-panel,
-.quick-add-panel {
+.snooze-dialog.is-open .snooze-dialog-backdrop,
+.quick-add.is-open .quick-add-backdrop {
+  opacity: 1;
+}
+
+.dialog-panel {
   position: absolute;
   top: 50%;
   left: 50%;
@@ -257,18 +247,14 @@ body {
   pointer-events: none;
 }
 
-.snooze-dialog.is-open .snooze-dialog-backdrop {
-  opacity: 1;
-}
-
-.snooze-dialog.is-open .snooze-dialog-panel {
+.snooze-dialog.is-open .dialog-panel,
+.quick-add.is-open .dialog-panel {
   opacity: 1;
   transform: translate(-50%, -50%) scale(1);
   pointer-events: auto;
 }
 
-.dialog-header,
-.snooze-dialog-header {
+.dialog-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -283,8 +269,7 @@ body {
   gap: 0.25rem;
 }
 
-.dialog-title,
-.snooze-dialog-title {
+.dialog-title {
   font-size: 1rem;
   font-weight: 700;
   color: var(--text-primary);
@@ -298,60 +283,12 @@ body {
   line-height: 1.45;
 }
 
-.snooze-dialog-header .icon-button {
+.dialog-header .icon-button {
   width: 28px;
   height: 28px;
 }
 
-.snooze-resume {
-  font-family: inherit;
-  font-size: 0.72rem;
-  padding: 0.38rem 0.62rem;
-  cursor: pointer;
-  text-align: center;
-}
-
-.snooze-resume[hidden] {
-  display: none;
-}
-
-.snooze-options {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.35rem;
-}
-
-.snooze-option {
-  font-family: inherit;
-  border: 1px solid var(--border);
-  background: var(--panel-soft);
-  color: var(--text-secondary);
-  border-radius: 999px;
-  font-size: 0.73rem;
-  padding: 0.36rem 0.55rem;
-  cursor: pointer;
-  text-align: center;
-  transition:
-    border-color 0.2s,
-    color 0.2s,
-    background 0.2s,
-    transform 0.2s;
-}
-
-.snooze-option:hover {
-  border-color: var(--panel-soft-border);
-  background: var(--panel-soft-hover);
-  color: var(--text-primary);
-}
-
-.snooze-option.is-active {
-  border-color: var(--panel-soft-border);
-  color: var(--panel-soft-strong);
-  background: var(--panel-soft-active);
-}
-
-.dialog-section,
-.snooze-section {
+.dialog-section {
   display: flex;
   flex-direction: column;
   gap: 0.42rem;
@@ -365,13 +302,74 @@ body {
   );
 }
 
-.dialog-section-title,
-.snooze-section-title {
+.dialog-section-title {
   font-size: 0.68rem;
   font-weight: 600;
   color: var(--text-muted);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+.dialog-chip {
+  font-family: inherit;
+  border: 1px solid var(--border);
+  background: var(--panel-soft);
+  color: var(--text-secondary);
+  border-radius: 999px;
+  font-size: 0.73rem;
+  padding: 0.32rem 0.55rem;
+  cursor: pointer;
+  text-align: center;
+  transition:
+    border-color 0.2s,
+    color 0.2s,
+    background 0.2s,
+    transform 0.2s;
+}
+
+.dialog-chip:hover {
+  border-color: var(--panel-soft-border);
+  background: var(--panel-soft-hover);
+  color: var(--text-primary);
+}
+
+.dialog-chip:active {
+  transform: scale(0.97);
+}
+
+.dialog-chip:focus-visible,
+.text-link:focus-visible {
+  outline: 2px solid var(--focus-ring-soft);
+  outline-offset: 2px;
+}
+
+.dialog-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dialog-actions > * {
+  flex: 1 1 calc(50% - 0.25rem);
+  min-width: 0;
+}
+
+.dialog-actions > .dialog-action-full {
+  flex-basis: 100%;
+}
+
+.dialog-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.72rem;
+}
+
+/* Snooze dialog specifics */
+.snooze-options {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.35rem;
 }
 
 .snooze-custom {
@@ -400,7 +398,6 @@ body {
   background-color: var(--button-primary-bg);
   color: var(--button-primary-text);
   border-color: var(--button-primary-border);
-  box-shadow: var(--button-primary-shadow);
   padding: 0.36rem 0.6rem;
   cursor: pointer;
   font-weight: 600;
@@ -410,174 +407,21 @@ body {
 }
 
 .snooze-custom-apply:hover {
-  border-color: var(--button-primary-border);
   background-color: var(--button-primary-hover-bg);
 }
 
-.dialog-actions,
-.snooze-dialog-actions {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.dialog-actions > * {
-  flex: 1 1 calc(50% - 0.25rem);
-  min-width: 0;
-}
-
-.dialog-actions > .dialog-action-full {
-  flex-basis: 100%;
-}
-
-.dialog-actions .button.ghost {
-  background: var(--panel-soft);
-  border: 1px solid var(--border);
-  color: var(--text-secondary);
-}
-
-.dialog-actions .button.ghost:hover {
-  background: var(--panel-soft-hover);
-  border-color: var(--panel-soft-border);
-  color: var(--text-primary);
-}
-
-.header-icon-button:hover {
-  background: var(--header-control-bg-hover);
-  border-color: var(--header-control-border-hover);
-}
-
-.header-icon-button:active {
-  transform: scale(0.96);
-}
-
-.header-icon-button:focus-visible {
-  outline: 2px solid var(--header-focus-ring);
-  outline-offset: 2px;
-}
-
-.header-icon-button:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
-.header-icon-button:disabled:hover {
-  background: var(--header-control-bg);
-  border-color: var(--header-control-border);
-}
-
-.button {
-  font-family: var(--font-sans);
-  padding: 0.45rem 0.9rem;
-  background-color: var(--button-primary-bg);
-  color: var(--button-primary-text);
-  border: 1px solid var(--button-primary-border);
-  border-radius: 999px;
-  cursor: pointer;
+.snooze-resume {
   font-size: 0.78rem;
-  font-weight: 600;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.35rem;
-  line-height: 1;
-  transition:
-    background-color 0.2s,
-    border-color 0.2s;
-  box-shadow: var(--button-primary-shadow);
+  padding: 0.45rem 0.62rem;
+  cursor: pointer;
+  text-align: center;
 }
 
-.button:hover {
-  background-color: var(--button-primary-hover-bg);
+.snooze-resume[hidden] {
+  display: none;
 }
 
-.button:focus-visible,
-.icon-button:focus-visible {
-  outline: 2px solid var(--focus-ring);
-  outline-offset: 2px;
-}
-
-.button.ghost {
-  background: var(--header-control-bg);
-  border: 1px solid var(--header-control-border);
-  box-shadow: none;
-}
-
-.button.ghost:hover {
-  background: var(--header-control-bg-hover);
-}
-
-.button.small {
-  padding: 0.4rem 0.75rem;
-  font-size: 0.74rem;
-}
-
-.content {
-  flex: 1 1 auto;
-  min-height: 0;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  position: relative;
-}
-
-.quick-add {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: 12;
-}
-
-.quick-add.is-open {
-  pointer-events: auto;
-}
-
-.quick-add-backdrop {
-  position: absolute;
-  inset: 0;
-  background: var(--modal-overlay);
-  opacity: 0;
-  transition: opacity 0.2s;
-}
-
-.quick-add.is-open .quick-add-backdrop {
-  opacity: 1;
-}
-
-.quick-add-panel {
-  gap: 0.76rem;
-}
-
-.quick-add.is-open .quick-add-panel {
-  opacity: 1;
-  transform: translate(-50%, -50%) scale(1);
-  pointer-events: auto;
-}
-
-.quick-add-eyebrow {
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.62rem;
-  font-weight: 700;
-  color: var(--text-muted);
-}
-
-.quick-add-title {
-  margin: 0;
-}
-
-.quick-add-subtitle {
-  margin: 0;
-}
-
-.dialog-form,
-.quick-add-form {
-  display: flex;
-  flex-direction: column;
-  gap: 0.72rem;
-}
-
+/* Quick add dialog specifics */
 .quick-add-row {
   display: flex;
   flex-direction: column;
@@ -591,10 +435,6 @@ body {
 
 .quick-add-duration .input {
   flex: 1;
-}
-
-.dialog-section .form-label {
-  margin: 0;
 }
 
 .form-label {
@@ -631,44 +471,6 @@ body {
   gap: 0.4rem;
 }
 
-.dialog-chip,
-.pill-button {
-  border: 1px solid var(--border);
-  background: var(--panel-soft);
-  color: var(--text-secondary);
-  border-radius: 999px;
-  padding: 0.28rem 0.56rem;
-  font-size: 0.71rem;
-  cursor: pointer;
-  transition:
-    border-color 0.2s,
-    color 0.2s,
-    background 0.2s,
-    transform 0.2s;
-}
-
-.pill-button:hover {
-  color: var(--text-primary);
-  border-color: var(--panel-soft-border);
-  background: var(--panel-soft-hover);
-}
-
-.pill-button:active {
-  transform: scale(0.97);
-}
-
-.pill-button:focus-visible,
-.text-link:focus-visible {
-  outline: 2px solid var(--focus-ring-soft);
-  outline-offset: 2px;
-}
-
-.quick-add-actions {
-  display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
 .text-link {
   border: none;
   background: none;
@@ -684,6 +486,16 @@ body {
   text-decoration: underline;
 }
 
+/* Filter list */
+.content {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  position: relative;
+}
+
 .filter-list {
   display: flex;
   flex-direction: column;
@@ -691,8 +503,13 @@ body {
   gap: 0.5rem;
   flex: 1 1 auto;
   min-height: 0;
-  overflow-y: overlay;
+  overflow-y: auto;
   overflow-x: hidden;
+}
+
+.filter-list::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .content.is-snoozed .filter-list > * {
@@ -717,11 +534,6 @@ body {
   z-index: 4;
 }
 
-.filter-list::-webkit-scrollbar {
-  width: 0;
-  height: 0;
-}
-
 .inactive-summary {
   font-size: 0.72rem;
   color: var(--text-muted);
@@ -731,11 +543,12 @@ body {
 
 .filter-item {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
   width: 100%;
   min-width: 0;
   padding: 0.6rem 0.7rem;
-  gap: 0.4rem;
+  gap: 0.75rem;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
@@ -745,12 +558,13 @@ body {
 .filter-info {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.2rem;
   min-width: 0;
+  flex: 1 1 auto;
 }
 
 .filter-name {
-  font-weight: 400;
+  font-weight: 500;
   font-size: 0.9rem;
   color: var(--text-primary);
   line-height: 1.35;
@@ -764,75 +578,41 @@ body {
   color: var(--text-secondary);
 }
 
-.filter-pattern {
-  font-family: 'SFMono-Regular', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
-  font-size: 0.78rem;
-  color: var(--text-secondary);
-  line-height: 1.35;
+.filter-group {
+  font-size: 0.7rem;
+  color: var(--text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.filter-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-shrink: 0;
 }
 
 .quick-actions {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
-.filter-footer {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.filter-group {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-  display: flex;
-  align-items: center;
-  flex: 1;
-  min-width: 0;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.quick-actions-bottom {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-left: auto;
-}
-
-.icon-button {
+.filter-item .icon-button {
   width: 30px;
   height: 30px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
+  border-color: var(--border);
   background: var(--panel-soft);
   color: var(--text-secondary);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  padding: 0;
-  flex-shrink: 0;
   position: relative;
-  transition:
-    transform 0.2s,
-    border-color 0.2s,
-    color 0.2s,
-    background 0.2s;
 }
 
-.icon-button[hidden] {
-  display: none;
-}
-
-.icon-button svg {
-  width: 16px;
-  height: 16px;
+.filter-item .icon-button:hover {
+  color: var(--text-primary);
+  border-color: var(--panel-soft-border);
+  background: var(--panel-soft-hover);
 }
 
 .icon-button .icon-copy,
@@ -874,64 +654,6 @@ body {
   }
 }
 
-.icon-button:hover {
-  color: var(--text-primary);
-  border-color: var(--panel-soft-border);
-  background: var(--panel-soft-hover);
-}
-
-.icon-button:active {
-  transform: scale(0.96);
-}
-
-.toggle {
-  position: relative;
-  display: inline-flex;
-  width: 44px;
-  height: 22px;
-  flex-shrink: 0;
-}
-
-.toggle input {
-  position: absolute;
-  opacity: 0;
-  inset: 0;
-}
-
-.toggle input:focus-visible + .slider {
-  box-shadow: 0 0 0 3px var(--focus-ring-soft);
-}
-
-.slider {
-  position: absolute;
-  inset: 0;
-  cursor: pointer;
-  background-color: var(--toggle-track);
-  transition: 0.3s;
-  border-radius: 22px;
-}
-
-.slider:before {
-  position: absolute;
-  content: '';
-  height: 16px;
-  width: 16px;
-  left: 3px;
-  bottom: 3px;
-  background-color: var(--toggle-thumb);
-  transition: 0.3s;
-  border-radius: 50%;
-  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
-}
-
-input:checked + .slider {
-  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
-}
-
-input:checked + .slider:before {
-  transform: translateX(22px);
-}
-
 .empty-state {
   text-align: center;
   padding: 20px 12px;
@@ -946,66 +668,41 @@ input:checked + .slider:before {
   font-size: 0.9rem;
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
-  white-space: nowrap;
+/* Footer action */
+.footer-bar {
+  padding: 0.5rem;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  flex-shrink: 0;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    color-scheme: dark;
-    --text-primary: #edf0ff;
-    --text-secondary: #c9d2f6;
-    --text-muted: #9da8d9;
-    --bg: #111328;
-    --surface: #191d3b;
-    --border: #343a74;
-    --accent: #95b0ed;
-    --accent-strong: #acd2f6;
-    --accent-deep: #7d8fe5;
-    --button-primary-bg: #6f79de;
-    --button-primary-hover-bg: #646fd8;
-    --button-primary-text: #f0f2ff;
-    --button-primary-border: rgba(172, 210, 246, 0.3);
-    --button-primary-shadow: none;
-    --bg-glow-primary: rgba(102, 109, 220, 0.42);
-    --bg-glow-secondary: rgba(78, 76, 211, 0.34);
-    --header-gradient-start: #3a32a9;
-    --header-gradient-mid: #4e4cd3;
-    --header-gradient-end: #666ddc;
-    --header-text: #f0f2ff;
-    --header-control-bg: rgba(219, 225, 255, 0.16);
-    --header-control-border: rgba(187, 199, 255, 0.38);
-    --header-control-bg-hover: rgba(226, 232, 255, 0.26);
-    --header-control-border-hover: rgba(207, 217, 255, 0.6);
-    --header-focus-ring: rgba(228, 232, 255, 0.9);
-    --snooze-bg: rgba(172, 210, 246, 0.3);
-    --snooze-border: rgba(196, 243, 255, 0.5);
-    --snooze-text: #e7f3ff;
-    --panel-soft: #202657;
-    --panel-soft-hover: #29306a;
-    --panel-soft-active: #323b7f;
-    --panel-soft-strong: #e2e8ff;
-    --panel-soft-border: rgba(149, 176, 237, 0.58);
-    --section-border: rgba(125, 143, 229, 0.38);
-    --section-gradient-start: #1f2551;
-    --section-gradient-end: #1a2044;
-    --modal-overlay: rgba(7, 8, 24, 0.74);
-    --overlay-muted: rgba(33, 38, 84, 0.62);
-    --focus-ring: rgba(149, 176, 237, 0.78);
-    --focus-ring-soft: rgba(149, 176, 237, 0.52);
-    --toggle-track: #5962a0;
-    --toggle-thumb: #e0e4fb;
-    --header-shadow: 0 14px 30px rgba(7, 8, 24, 0.52);
-    --dialog-shadow: 0 24px 50px rgba(7, 8, 24, 0.58);
-    --shadow-sm: 0 10px 24px rgba(7, 8, 24, 0.34);
-    --empty-surface: rgba(20, 24, 56, 0.72);
-  }
+.footer-action {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  font-size: 0.85rem;
+}
+
+.footer-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.footer-action:disabled:hover {
+  background-color: var(--button-primary-bg);
+}
+
+/* Popup-scale button sizing */
+.button {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.78rem;
+}
+
+.button.small {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.74rem;
+}
+
+.footer-bar .button {
+  padding: 0.6rem 1rem;
+  font-size: 0.85rem;
 }

--- a/src/entrypoints/popup/styles/popup.css
+++ b/src/entrypoints/popup/styles/popup.css
@@ -40,7 +40,7 @@ body {
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
-  box-shadow: var(--header-shadow);
+  box-shadow: 0 4px 14px rgba(48, 43, 126, 0.14);
   position: relative;
   z-index: 5;
   flex-shrink: 0;
@@ -106,19 +106,19 @@ body {
 
 .snooze-button {
   width: 100%;
+  min-height: 40px;
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   background: var(--surface);
   color: var(--text-primary);
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  padding: 0.55rem 0.7rem;
+  gap: 0.55rem;
+  padding: 0 0.8rem;
   font-family: inherit;
   font-size: 0.8rem;
   font-weight: 600;
   cursor: pointer;
-  box-shadow: var(--shadow-sm);
   transition:
     background 0.2s,
     border-color 0.2s;
@@ -134,48 +134,42 @@ body {
   outline-offset: 2px;
 }
 
-.snooze-button .snooze-icon {
-  width: 18px;
-  height: 18px;
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   flex: 0 0 auto;
-  color: var(--accent-deep);
-}
-
-.snooze-status {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.12rem;
-  min-width: 0;
-  text-align: left;
-}
-
-.snooze-status-heading {
-  font-size: 0.62rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  background: var(--status-active);
+  box-shadow: 0 0 0 3px var(--status-active-glow);
 }
 
 .snooze-trigger-text {
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
   line-height: 1;
 }
 
-.snooze-chevron {
+.snooze-hint {
   margin-left: auto;
   display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
   color: var(--text-muted);
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1;
 }
 
-.snooze-chevron svg {
+.snooze-hint-icon {
   width: 14px;
   height: 14px;
+  flex: 0 0 auto;
 }
 
-.snooze-trigger .snooze-icon-on {
-  display: none;
+.snooze-button:hover .snooze-hint {
+  color: var(--text-secondary);
 }
 
 .snooze-trigger.is-snoozed {
@@ -184,16 +178,14 @@ body {
   color: var(--snooze-text);
 }
 
-.snooze-trigger.is-snoozed .snooze-icon {
-  color: currentColor;
+.snooze-trigger.is-snoozed .status-dot {
+  background: var(--status-snoozed);
+  box-shadow: 0 0 0 3px var(--status-snoozed-glow);
 }
 
-.snooze-trigger.is-snoozed .snooze-icon-off {
-  display: none;
-}
-
-.snooze-trigger.is-snoozed .snooze-icon-on {
-  display: block;
+.snooze-trigger.is-snoozed .snooze-hint {
+  color: inherit;
+  opacity: 0.75;
 }
 
 /* Dialog overlays (snooze + quick add share the pattern) */
@@ -303,11 +295,9 @@ body {
 }
 
 .dialog-section-title {
-  font-size: 0.68rem;
+  font-size: 0.74rem;
   font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: var(--text-secondary);
 }
 
 .dialog-chip {
@@ -438,11 +428,9 @@ body {
 }
 
 .form-label {
-  font-size: 0.68rem;
+  font-size: 0.74rem;
   font-weight: 600;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  color: var(--text-secondary);
 }
 
 .input {

--- a/src/entrypoints/popup/styles/popup.css
+++ b/src/entrypoints/popup/styles/popup.css
@@ -48,6 +48,7 @@ body {
 
 .header .app-title {
   font-size: 1.2rem;
+  flex-shrink: 0;
 }
 
 .header .app-icon {
@@ -59,6 +60,11 @@ body {
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  min-width: 0;
+}
+
+.header-actions .header-icon-button {
+  flex-shrink: 0;
 }
 
 .header-icon-button {
@@ -97,50 +103,54 @@ body {
   outline-offset: 2px;
 }
 
-/* Status bar: filtering state / snooze entry point */
-.status-bar {
+/* Snooze chip in the header */
+.snooze-popover {
   position: relative;
-  padding: 0.5rem 0.5rem 0;
-  flex-shrink: 0;
+  min-width: 0;
 }
 
 .snooze-button {
-  width: 100%;
-  min-height: 40px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: var(--surface);
-  color: var(--text-primary);
-  display: flex;
+  border: 1px solid var(--header-control-border);
+  border-radius: 999px;
+  background: var(--header-control-bg);
+  color: var(--header-text);
+  display: inline-flex;
   align-items: center;
-  gap: 0.55rem;
-  padding: 0 0.8rem;
+  gap: 0.4rem;
+  height: 30px;
+  max-width: 100%;
+  padding: 0 0.7rem;
   font-family: inherit;
-  font-size: 0.8rem;
+  font-size: 0.74rem;
   font-weight: 600;
   cursor: pointer;
   transition:
     background 0.2s,
-    border-color 0.2s;
+    border-color 0.2s,
+    transform 0.2s;
 }
 
 .snooze-button:hover {
-  background: var(--panel-soft-hover);
-  border-color: var(--panel-soft-border);
+  background: var(--header-control-bg-hover);
+  border-color: var(--header-control-border-hover);
+}
+
+.snooze-button:active {
+  transform: scale(0.96);
 }
 
 .snooze-button:focus-visible {
-  outline: 2px solid var(--focus-ring);
+  outline: 2px solid var(--header-focus-ring);
   outline-offset: 2px;
 }
 
 .status-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 50%;
   flex: 0 0 auto;
   background: var(--status-active);
-  box-shadow: 0 0 0 3px var(--status-active-glow);
+  box-shadow: 0 0 0 2.5px var(--status-active-glow);
 }
 
 .snooze-trigger-text {
@@ -151,27 +161,6 @@ body {
   line-height: 1;
 }
 
-.snooze-hint {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.3rem;
-  color: var(--text-muted);
-  font-size: 0.72rem;
-  font-weight: 500;
-  line-height: 1;
-}
-
-.snooze-hint-icon {
-  width: 14px;
-  height: 14px;
-  flex: 0 0 auto;
-}
-
-.snooze-button:hover .snooze-hint {
-  color: var(--text-secondary);
-}
-
 .snooze-trigger.is-snoozed {
   background: var(--snooze-bg);
   border-color: var(--snooze-border);
@@ -180,12 +169,7 @@ body {
 
 .snooze-trigger.is-snoozed .status-dot {
   background: var(--status-snoozed);
-  box-shadow: 0 0 0 3px var(--status-snoozed-glow);
-}
-
-.snooze-trigger.is-snoozed .snooze-hint {
-  color: inherit;
-  opacity: 0.75;
+  box-shadow: 0 0 0 2.5px var(--status-snoozed-glow);
 }
 
 /* Dialog overlays (snooze + quick add share the pattern) */

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -1,0 +1,385 @@
+/**
+ * Shared Teichos theme: design tokens and UI primitives used by every entrypoint.
+ * Page stylesheets import this file and only add page-specific layout on top.
+ */
+
+* {
+  box-sizing: border-box;
+}
+
+:root {
+  color-scheme: light;
+  --font-sans:
+    'Avenir Next', 'SF Pro Text', 'Segoe UI Variable', 'Segoe UI', 'Noto Sans', sans-serif;
+  --font-display:
+    'Space Grotesk', 'Avenir Next', 'SF Pro Display', 'Segoe UI Variable', 'Segoe UI', sans-serif;
+  --font-mono: 'SFMono-Regular', 'Menlo', 'Consolas', 'Liberation Mono', monospace;
+
+  --text-primary: #0f172a;
+  --text-secondary: #44556f;
+  --text-muted: #7689a8;
+  --bg: #f3f7fc;
+  --surface: #ffffff;
+  --surface-muted: #f3f7ff;
+  --border: #d7e1ef;
+
+  --accent: #666ddc;
+  --accent-strong: #7d8fe5;
+  --accent-deep: #4e4cd3;
+
+  --button-primary-bg: #666ddc;
+  --button-primary-hover-bg: #5a61cf;
+  --button-primary-text: #f7f8ff;
+  --button-primary-border: rgba(78, 76, 211, 0.42);
+  --button-primary-shadow: none;
+  --danger: #ef4444;
+  --danger-hover: #dc2626;
+
+  --bg-glow-primary: rgba(172, 210, 246, 0.28);
+  --bg-glow-secondary: rgba(102, 109, 220, 0.2);
+  --header-gradient-start: #4e4cd3;
+  --header-gradient-mid: #666ddc;
+  --header-gradient-end: #7d8fe5;
+  --header-text: #f7f8ff;
+  --header-subtitle: rgba(247, 248, 255, 0.92);
+  --header-control-bg: rgba(255, 255, 255, 0.17);
+  --header-control-border: rgba(255, 255, 255, 0.45);
+  --header-control-bg-hover: rgba(255, 255, 255, 0.28);
+  --header-control-border-hover: rgba(255, 255, 255, 0.72);
+  --header-focus-ring: rgba(240, 248, 255, 0.94);
+
+  --panel-soft: #f5f6ff;
+  --panel-soft-hover: #eaeeff;
+  --panel-soft-active: #dde3ff;
+  --panel-soft-strong: #2b327d;
+  --panel-soft-border: rgba(102, 109, 220, 0.42);
+  --section-border: rgba(141, 156, 222, 0.29);
+  --section-gradient-start: #fcfcff;
+  --section-gradient-end: #f4f6ff;
+  --group-header-start: #fafbff;
+  --group-header-end: #f0f3ff;
+
+  --modal-overlay: rgba(12, 23, 42, 0.48);
+  --overlay-muted: rgba(149, 165, 232, 0.35);
+  --focus-ring: rgba(102, 109, 220, 0.68);
+  --focus-ring-soft: rgba(102, 109, 220, 0.44);
+  --toggle-track: #b9c0ea;
+  --toggle-thumb: #ffffff;
+  --icon-border: #d7e1ef;
+  --icon-color: #5a6298;
+  --empty-surface: rgba(255, 255, 255, 0.78);
+
+  --snooze-bg: rgba(172, 210, 246, 0.4);
+  --snooze-border: rgba(196, 243, 255, 0.9);
+  --snooze-text: #24306f;
+
+  --info-badge-bg: #303a8f;
+  --info-badge-text: #f7f8ff;
+  --info-badge-shadow: 0 10px 24px rgba(40, 44, 118, 0.26);
+  --info-badge-shadow-hover: 0 12px 28px rgba(40, 44, 118, 0.32);
+
+  --header-shadow: 0 12px 28px rgba(48, 43, 126, 0.24);
+  --dialog-shadow: 0 20px 40px rgba(34, 35, 94, 0.22);
+  --shadow-sm: 0 6px 16px rgba(38, 41, 102, 0.1);
+  --shadow-lg: 0 20px 50px rgba(35, 38, 98, 0.24);
+
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --text-primary: #edf0ff;
+    --text-secondary: #c9d2f6;
+    --text-muted: #9da8d9;
+    --bg: #111328;
+    --surface: #191d3b;
+    --surface-muted: #202657;
+    --border: #343a74;
+
+    --accent: #95b0ed;
+    --accent-strong: #acd2f6;
+    --accent-deep: #7d8fe5;
+
+    --button-primary-bg: #6f79de;
+    --button-primary-hover-bg: #646fd8;
+    --button-primary-text: #f0f2ff;
+    --button-primary-border: rgba(172, 210, 246, 0.3);
+    --danger: #f87171;
+    --danger-hover: #ef4444;
+
+    --bg-glow-primary: rgba(102, 109, 220, 0.42);
+    --bg-glow-secondary: rgba(78, 76, 211, 0.34);
+    --header-gradient-start: #3a32a9;
+    --header-gradient-mid: #4e4cd3;
+    --header-gradient-end: #666ddc;
+    --header-text: #f0f2ff;
+    --header-subtitle: rgba(228, 233, 255, 0.9);
+    --header-control-bg: rgba(219, 225, 255, 0.16);
+    --header-control-border: rgba(187, 199, 255, 0.38);
+    --header-control-bg-hover: rgba(226, 232, 255, 0.26);
+    --header-control-border-hover: rgba(207, 217, 255, 0.6);
+    --header-focus-ring: rgba(228, 232, 255, 0.9);
+
+    --panel-soft: #202657;
+    --panel-soft-hover: #29306a;
+    --panel-soft-active: #323b7f;
+    --panel-soft-strong: #e2e8ff;
+    --panel-soft-border: rgba(149, 176, 237, 0.58);
+    --section-border: rgba(125, 143, 229, 0.38);
+    --section-gradient-start: #1f2551;
+    --section-gradient-end: #1a2044;
+    --group-header-start: #252d66;
+    --group-header-end: #1f2658;
+
+    --modal-overlay: rgba(7, 8, 24, 0.74);
+    --overlay-muted: rgba(33, 38, 84, 0.62);
+    --focus-ring: rgba(149, 176, 237, 0.78);
+    --focus-ring-soft: rgba(149, 176, 237, 0.4);
+    --toggle-track: #5962a0;
+    --toggle-thumb: #e0e4fb;
+    --icon-border: #3d4486;
+    --icon-color: #b0baea;
+    --empty-surface: rgba(20, 24, 56, 0.72);
+
+    --snooze-bg: rgba(172, 210, 246, 0.3);
+    --snooze-border: rgba(196, 243, 255, 0.5);
+    --snooze-text: #e7f3ff;
+
+    --info-badge-bg: #323a8f;
+    --info-badge-text: #f0f2ff;
+    --info-badge-shadow: 0 12px 30px rgba(12, 14, 44, 0.46);
+    --info-badge-shadow-hover: 0 14px 32px rgba(12, 14, 44, 0.52);
+
+    --header-shadow: 0 16px 36px rgba(7, 8, 24, 0.54);
+    --dialog-shadow: 0 24px 50px rgba(7, 8, 24, 0.58);
+    --shadow-sm: 0 10px 24px rgba(7, 8, 24, 0.34);
+    --shadow-lg: 0 24px 58px rgba(7, 8, 24, 0.62);
+  }
+}
+
+/* Accessibility helpers */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+  white-space: nowrap;
+}
+
+/* Brand */
+.app-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.app-icon {
+  display: block;
+  flex: 0 0 auto;
+  transform: translateY(1px);
+}
+
+/* Buttons */
+.button {
+  font-family: var(--font-sans);
+  padding: 0.55rem 1rem;
+  background-color: var(--button-primary-bg);
+  color: var(--button-primary-text);
+  border: 1px solid var(--button-primary-border);
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.88rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  line-height: 1;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s,
+    box-shadow 0.2s;
+  box-shadow: var(--button-primary-shadow);
+}
+
+.button:hover {
+  background-color: var(--button-primary-hover-bg);
+}
+
+.button:focus-visible,
+.icon-button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 2px;
+}
+
+.button.secondary {
+  background: var(--panel-soft);
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+.button.secondary:hover {
+  background: var(--panel-soft-hover);
+  border-color: var(--panel-soft-border);
+  color: var(--panel-soft-strong);
+}
+
+.button.ghost {
+  background: var(--panel-soft);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+  box-shadow: none;
+}
+
+.button.ghost:hover {
+  background: var(--panel-soft-hover);
+  border-color: var(--panel-soft-border);
+  color: var(--text-primary);
+}
+
+.button.danger {
+  background: var(--danger);
+  border-color: transparent;
+  box-shadow: none;
+}
+
+.button.danger:hover {
+  background: var(--danger-hover);
+}
+
+.button.small {
+  padding: 0.42rem 0.8rem;
+  font-size: 0.78rem;
+  box-shadow: none;
+}
+
+.button-icon {
+  display: inline-flex;
+  width: 14px;
+  height: 14px;
+}
+
+.button-icon svg {
+  width: 100%;
+  height: 100%;
+}
+
+.icon-button {
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  border: 1px solid var(--icon-border);
+  background: transparent;
+  color: var(--icon-color);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+  flex-shrink: 0;
+  transition:
+    background 0.2s,
+    border-color 0.2s,
+    color 0.2s,
+    transform 0.2s;
+}
+
+.icon-button.small {
+  width: 28px;
+  height: 28px;
+}
+
+.icon-button svg {
+  width: 16px;
+  height: 16px;
+}
+
+.icon-button .button-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.icon-button.small .button-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.icon-button:hover {
+  background: var(--panel-soft-hover);
+  border-color: var(--panel-soft-border);
+  color: var(--panel-soft-strong);
+}
+
+.icon-button:active {
+  transform: scale(0.96);
+}
+
+.icon-button:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.icon-button[hidden] {
+  display: none;
+}
+
+/* Toggle switch */
+.toggle {
+  position: relative;
+  display: inline-flex;
+  width: 44px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  inset: 0;
+}
+
+.toggle input:focus-visible + .slider {
+  box-shadow: 0 0 0 3px var(--focus-ring-soft);
+}
+
+.slider {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+  background-color: var(--toggle-track);
+  transition: 0.3s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: '';
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: var(--toggle-thumb);
+  transition: 0.3s;
+  border-radius: 50%;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
+}
+
+input:checked + .slider {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+}
+
+input:checked + .slider:before {
+  transform: translateX(22px);
+}

--- a/src/shared/styles/theme.css
+++ b/src/shared/styles/theme.css
@@ -72,6 +72,10 @@
   --snooze-bg: rgba(172, 210, 246, 0.4);
   --snooze-border: rgba(196, 243, 255, 0.9);
   --snooze-text: #24306f;
+  --status-active: #34c76f;
+  --status-active-glow: rgba(52, 199, 111, 0.22);
+  --status-snoozed: #f0a72c;
+  --status-snoozed-glow: rgba(240, 167, 44, 0.24);
 
   --info-badge-bg: #303a8f;
   --info-badge-text: #f7f8ff;
@@ -147,6 +151,10 @@
     --snooze-bg: rgba(172, 210, 246, 0.3);
     --snooze-border: rgba(196, 243, 255, 0.5);
     --snooze-text: #e7f3ff;
+    --status-active: #4ade80;
+    --status-active-glow: rgba(74, 222, 128, 0.25);
+    --status-snoozed: #fbbf24;
+    --status-snoozed-glow: rgba(251, 191, 36, 0.26);
 
     --info-badge-bg: #323a8f;
     --info-badge-text: #f0f2ff;


### PR DESCRIPTION
## Summary

A ground-up layout pass over every surface — popup, options, and block page — keeping the existing theme (indigo palette, gradients, Space Grotesk, dark mode) but making the structure calmer, more consistent, and easier to use.

- New `src/shared/styles/theme.css` holds all design tokens and shared primitives (buttons, toggles, icon buttons); the three page stylesheets previously carried divergent copies and now only add page layout.
- Coherent tab titles: `Teichos` (popup), `Settings · Teichos` (options), `Blocked · Teichos` (block page); terminology unified around "Settings" and "temporary block".
- Every test-pinned ID, class, data-action, and accessible name was preserved.

## Popup

Header slimmed to brand + snooze chip + settings gear. The snooze chip shows filtering state at a glance with a colored status dot (green active, amber snoozed). Filter cards are flattened to single rows, and the unlabeled `+` icon is replaced by a labeled **New temporary block** footer action.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/341bfd96-aec8-4d04-9369-bbbfb4b57f31" />

### Snoozed state

The chip tints and switches to an amber dot with the remaining time; the list dims and locks while filtering is paused.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/bf6414ff-0065-41fe-9476-b7d04fa885ea" />

### Indefinite snooze

Long labels ellipsize cleanly without crowding the brand.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/72a8b456-d384-4b4f-83de-4ea5b50aa4c6" />

### Dark mode

All surfaces share one token set, so dark mode stays coherent everywhere.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/e6a4389b-2be6-49b5-bae2-3908ffd62983" />

### Temporary block dialog

Quick-add now reads as a proper dialog with sentence-case labels, duration presets, and a link to the full editor.

<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/7c543779-2da9-4c2d-8963-e3a3631548c9" />

## Options

Compact brand header (tagline removed). Two clearly named sections: **Groups**, with the New Group action beside the heading and a one-line hint, and **General**, a proper card for extension-wide preferences and backups instead of a fake collapsible group. Content column narrowed to 880px; SVG chevrons replace the unicode arrows.

<img width="1280" height="1562" alt="image" src="https://github.com/user-attachments/assets/24446a2a-0462-4fa0-ab1e-32c1b06549f4" />

### Dark mode

<img width="1280" height="1562" alt="image" src="https://github.com/user-attachments/assets/82c65f3d-0771-4861-972b-9228b85e1fa5" />

### Group editor

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/15d1546c-a127-44dd-b9ad-843ef0758a16" />

## Block page

Aligned fonts and radii with the shared theme. Action hierarchy fixed: **Go Back** is the single primary button; Continue (bypass) and Manage Filters are quiet secondaries.

<img width="1280" height="960" alt="image" src="https://github.com/user-attachments/assets/afd04f23-d5fc-450c-b3df-09eb2d798842" />

## Testing

- `check:fast` passes (format, lint, typecheck, 159 unit tests)
- All 43 Playwright e2e tests pass
- Manually reviewed real-size screenshots of every surface, light and dark, including all dialogs and modals